### PR TITLE
Wait out in-progress swaps instead of 503 on concurrent requests (#19)

### DIFF
--- a/libs/gateway/include/gateway/routes.hpp
+++ b/libs/gateway/include/gateway/routes.hpp
@@ -53,6 +53,19 @@ struct SwapStartResult {
 
 SwapStartResult start_swap_async(const GatewayDeps& deps, const std::string& model_name);
 
+struct EnsureLoadedResult {
+    bool ok{false};
+    int status{503};
+    std::string code{};
+    std::string message{};
+};
+
+// Ensure `model_name` is loaded, waiting out any in-progress swap (e.g. two
+// concurrent requests racing on a cold model) rather than returning 503. On
+// failure, `status`/`code`/`message` describe the error for the caller to emit.
+EnsureLoadedResult ensure_model_loaded(const GatewayDeps& deps,
+                                       const std::string& model_name);
+
 void handle_models(const httplib::Request& req, httplib::Response& resp,
                    const GatewayDeps& deps);
 

--- a/libs/gateway/src/anthropic_routes.cpp
+++ b/libs/gateway/src/anthropic_routes.cpp
@@ -402,38 +402,15 @@ void handle_anthropic_messages(const httplib::Request& req, httplib::Response& r
         return;
     }
 
-    if (!deps.coordinator.is_loaded(model_name)) {
-        if (deps.auto_swap) {
-            auto started = start_swap_async(deps, model_name);
-            if (started.status >= 400) {
-                write_anthropic_error(resp, 503, "overloaded_error",
-                                      started.body.dump());
-                return;
+    {
+        auto loaded = ensure_model_loaded(deps, model_name);
+        if (!loaded.ok) {
+            if (loaded.status == 503) {
+                resp.set_header("Retry-After", deps.default_swap_timeout_s);
             }
-            // start_swap_async runs in the background; wait for the load,
-            // bailing early if the tracker reports the swap ended in failure.
-            const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes{5};
-            while (!deps.coordinator.is_loaded(model_name) &&
-                   std::chrono::steady_clock::now() < deadline) {
-                if (deps.swap_tracker) {
-                    const auto snap = deps.swap_tracker->snapshot();
-                    if (!snap.swapping && !snap.last_error.empty()) {
-                        write_anthropic_error(resp, 503, "overloaded_error",
-                                              "model load failed: " + snap.last_error);
-                        return;
-                    }
-                }
-                std::this_thread::sleep_for(std::chrono::milliseconds{200});
-            }
-            if (!deps.coordinator.is_loaded(model_name)) {
-                write_anthropic_error(resp, 503, "overloaded_error",
-                                      "model load timed out: " + model_name);
-                return;
-            }
-        } else {
-            resp.set_header("Retry-After", deps.default_swap_timeout_s);
-            write_anthropic_error(resp, 503, "overloaded_error",
-                                  "model not loaded: " + model_name);
+            const char* type =
+                loaded.status == 404 ? "not_found_error" : "overloaded_error";
+            write_anthropic_error(resp, loaded.status, type, loaded.message);
             return;
         }
     }

--- a/libs/gateway/src/routes.cpp
+++ b/libs/gateway/src/routes.cpp
@@ -361,6 +361,55 @@ SwapStartResult start_swap_async(const GatewayDeps& deps, const std::string& mod
                   {"from", from}}};
 }
 
+EnsureLoadedResult ensure_model_loaded(const GatewayDeps& deps,
+                                       const std::string& model_name) {
+    if (deps.coordinator.is_loaded(model_name)) {
+        return {true, 200, "", ""};
+    }
+    if (!deps.auto_swap) {
+        return {false, 503, "model_not_loaded",
+                "model not loaded; POST /v1/swap/to/" + model_name + " then retry"};
+    }
+
+    LOG_INFO("auto_swap_begin", "requested={}", model_name);
+    // Wait out any in-progress swap rather than failing fast with 503. A cold-start
+    // race (e.g. a client firing a title + main request at the same time) resolves
+    // when the first swap finishes and the target becomes loaded -- no redundant
+    // swap, no 503.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes{5};
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (deps.coordinator.is_loaded(model_name)) {
+            return {true, 200, "", ""};
+        }
+
+        auto started = start_swap_async(deps, model_name);
+        if (started.status == 404) {
+            return {false, 404, "model_not_found",
+                    "model not registered: " + model_name};
+        }
+        // status 200 (already loaded), 202 (we started the swap), or 409 (another
+        // swap already in progress): in every case wait for the model to load.
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (deps.coordinator.is_loaded(model_name)) {
+                return {true, 200, "", ""};
+            }
+            const auto snap =
+                deps.swap_tracker ? deps.swap_tracker->snapshot() : SwapSnapshot{};
+            if (!snap.swapping && !deps.coordinator.swap_in_progress()) {
+                // The in-progress swap settled. If it targeted our model and failed,
+                // surface that; otherwise re-evaluate and start our own swap.
+                if (snap.target == model_name && !snap.last_error.empty()) {
+                    return {false, 503, "swap_failed",
+                            "model load failed: " + snap.last_error};
+                }
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        }
+    }
+    return {false, 503, "swap_in_progress", "model load timed out: " + model_name};
+}
+
 void handle_swap_to(const httplib::Request& req, httplib::Response& resp,
                     const GatewayDeps& deps, const std::string& model_name) {
     (void)req;
@@ -422,29 +471,13 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
                     "model not registered: " + model_name);
         return;
     }
-    if (!deps.coordinator.is_loaded(model_name)) {
-        if (deps.auto_swap) {
-            LOG_INFO("auto_swap_begin", "requested={}", model_name);
-            const auto from_model = deps.coordinator.get_loaded_model();
-            if (!begin_tracked_swap(deps, from_model.value_or(""), model_name)) {
+    {
+        auto loaded = ensure_model_loaded(deps, model_name);
+        if (!loaded.ok) {
+            if (loaded.status == 503) {
                 resp.set_header("Retry-After", deps.default_swap_timeout_s);
-                write_error(resp, 503, "swap_in_progress",
-                            "another model swap is in progress; retry shortly");
-                return;
             }
-            auto swap_result = perform_swap(deps, from_model.value_or(""), model_name);
-            if (!swap_result) {
-                LOG_ERROR("auto_swap_failed", "model={} error={}", model_name, swap_result.error().message);
-                write_error(resp, 500, "swap_failed", swap_result.error().message);
-                return;
-            }
-            LOG_INFO("auto_swap_complete", "model={}", model_name);
-        } else {
-            resp.status = 503;
-            resp.set_header("Retry-After", deps.default_swap_timeout_s);
-            write_error(resp, 503, "model_not_loaded",
-                        "model not loaded; POST /v1/swap/to/" + model_name +
-                        " then retry");
+            write_error(resp, loaded.status, loaded.code, loaded.message);
             return;
         }
     }

--- a/libs/gateway/tests/test_routes.cpp
+++ b/libs/gateway/tests/test_routes.cpp
@@ -33,6 +33,7 @@ public:
     std::atomic<bool> loaded{false};
     std::atomic<int> vram_mb{4096};
     std::atomic<int> max_slots{2};
+    std::atomic<int> load_delay_ms{0};
     std::vector<int> busy_slots;
     mutable std::mutex mtx;
     ChatTemplateMeta chat_meta_{};
@@ -44,7 +45,12 @@ public:
     const ModelInfo& info() const override { return model_info; }
     const ChatTemplateMeta& chat_template_meta() const override { return chat_meta_; }
 
-    Result<void> load() override { loaded.store(true); return Ok(); }
+    Result<void> load() override {
+        const int delay = load_delay_ms.load();
+        if (delay > 0) std::this_thread::sleep_for(std::chrono::milliseconds{delay});
+        loaded.store(true);
+        return Ok();
+    }
     Result<void> unload() override {
         loaded.store(false);
         std::lock_guard<std::mutex> lock(mtx);
@@ -436,4 +442,72 @@ TEST_CASE("Routes: streaming tool call emits llama-server shaped SSE",
     REQUIRE(usage[0].prompt_tokens == 8);
     REQUIRE(usage[0].completion_tokens == 12);
     ts.stop();
+}
+
+TEST_CASE("ensure_model_loaded: already-loaded model returns ok immediately", "[routes][swap]") {
+    ModelRegistry registry;
+    registry.set_factory([](const ModelInfo& info) {
+        return std::make_unique<IModelMock>(info);
+    });
+    registry.register_model(make_info("a"));
+    BackendCoordinator coordinator(registry);
+    REQUIRE(coordinator.load("a"));
+    SwapTracker tracker;
+    GatewayDeps deps{coordinator, "10"};
+    deps.auto_swap = true;
+    deps.swap_tracker = &tracker;
+
+    auto r = ensure_model_loaded(deps, "a");
+    REQUIRE(r.ok);
+    REQUIRE(r.status == 200);
+}
+
+TEST_CASE("ensure_model_loaded: auto_swap disabled yields 503 for a cold model", "[routes][swap]") {
+    ModelRegistry registry;
+    registry.set_factory([](const ModelInfo& info) {
+        return std::make_unique<IModelMock>(info);
+    });
+    registry.register_model(make_info("a"));
+    BackendCoordinator coordinator(registry);
+    SwapTracker tracker;
+    GatewayDeps deps{coordinator, "10"};
+    deps.auto_swap = false;
+    deps.swap_tracker = &tracker;
+
+    auto r = ensure_model_loaded(deps, "a");
+    REQUIRE_FALSE(r.ok);
+    REQUIRE(r.status == 503);
+    REQUIRE(r.code == "model_not_loaded");
+}
+
+// Regression for issue #19: two requests racing on a cold model (e.g. OpenCode's
+// title + main calls) must both succeed; the second waits out the in-progress
+// swap instead of getting 503 swap_in_progress.
+TEST_CASE("ensure_model_loaded: concurrent callers wait out the swap, no 503", "[routes][swap]") {
+    ModelRegistry registry;
+    registry.set_factory([](const ModelInfo& info) {
+        auto m = std::make_unique<IModelMock>(info);
+        m->load_delay_ms.store(300);  // make the swap slow enough to overlap
+        return m;
+    });
+    registry.register_model(make_info("a"));
+    BackendCoordinator coordinator(registry);
+    SwapTracker tracker;
+    GatewayDeps deps{coordinator, "10"};
+    deps.auto_swap = true;
+    deps.swap_tracker = &tracker;
+
+    REQUIRE_FALSE(coordinator.is_loaded("a"));
+
+    EnsureLoadedResult r0, r1;
+    std::thread t0([&]() { r0 = ensure_model_loaded(deps, "a"); });
+    std::thread t1([&]() { r1 = ensure_model_loaded(deps, "a"); });
+    t0.join();
+    t1.join();
+
+    REQUIRE(r0.ok);
+    REQUIRE(r1.ok);
+    REQUIRE(r0.status == 200);
+    REQUIRE(r1.status == 200);
+    REQUIRE(coordinator.is_loaded("a"));
 }


### PR DESCRIPTION
## Problem
OpenCode fires its title (`agent=title`) and main (`agent=plan`) completion calls near-simultaneously. When the target model is cold, the first request triggers a model swap and the second receives `503 swap_in_progress`. The client retries, producing the observed "hangs" — confirmed in the OpenCode client log (`statusCode:503 {"code":"swap_in_progress"}`) and the gateway log (two `auto_swap_begin`, one `status=503` at the same instant).

## Fix
New shared `ensure_model_loaded(deps, model_name)` helper that **waits out an in-progress swap and re-checks `is_loaded`** instead of failing fast:
- same-model cold-start race → the 2nd caller waits for the 1st swap to finish, then proceeds (no redundant swap, no 503);
- different-model swap in progress → awaited, then the caller starts its own swap;
- bounded by a 5-minute deadline → `503` only on genuine timeout; `404` for unregistered models; `503 swap_failed` if the load errored.

Both `handle_chat_completions` (OpenAI) and `handle_anthropic_messages` (Anthropic) now route through it, removing duplicated/inconsistent swap-wait logic. The manual `POST /v1/swap/to/:name` endpoint keeps its explicit `409` conflict behavior.

## Tests
`route_tests` gains coverage for: already-loaded → ok; auto_swap disabled → `503 model_not_loaded`; and the regression — two concurrent callers on a cold (slow-loading) model both succeed with no `503`. Full `ctest -L "unit|integration"` green (6/6).

Fixes #19