### PR TITLE
Free state mutex during decode and make streaming cancellable (#28)

### DIFF
--- a/libs/gateway/src/anthropic_routes.cpp
+++ b/libs/gateway/src/anthropic_routes.cpp
@@ -565,7 +565,8 @@ void handle_anthropic_messages(const httplib::Request& req, httplib::Response& r
                     }
                     state->cv.notify_one();
                     return !state->aborted.load();
-                });
+                },
+                &state->aborted);
             {
                 std::lock_guard<std::mutex> lk(state->mtx);
                 if (result) {

--- a/libs/gateway/src/routes.cpp
+++ b/libs/gateway/src/routes.cpp
@@ -693,7 +693,8 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
                     }
                     state->cv.notify_one();
                 return !state->aborted.load();
-            });
+            },
+            &state->aborted);
             {
                 std::lock_guard<std::mutex> lk(state->mtx);
                 if (result) {

--- a/libs/gateway/tests/test_routes.cpp
+++ b/libs/gateway/tests/test_routes.cpp
@@ -34,6 +34,7 @@ public:
     std::atomic<int> vram_mb{4096};
     std::atomic<int> max_slots{2};
     std::atomic<int> load_delay_ms{0};
+    std::atomic<bool> block_until_cancel{false};
     std::vector<int> busy_slots;
     mutable std::mutex mtx;
     ChatTemplateMeta chat_meta_{};
@@ -103,7 +104,15 @@ public:
     }
 
     Result<InferenceResult> predict_stream(
-        int, const InferenceRequest&, const TokenCallback& callback) override {
+        int, const InferenceRequest&, const TokenCallback& callback,
+        const std::atomic<bool>* cancel = nullptr) override {
+        if (block_until_cancel.load()) {
+            // Simulate a long generation that only ends when cancelled.
+            while (!(cancel && cancel->load())) {
+                std::this_thread::sleep_for(std::chrono::milliseconds{5});
+            }
+            return Ok(InferenceResult{});
+        }
         InferenceDelta reasoning;
         reasoning.reasoning_text = "need a tool";
         if (!callback(reasoning)) return Ok(InferenceResult{});
@@ -510,4 +519,39 @@ TEST_CASE("ensure_model_loaded: concurrent callers wait out the swap, no 503", "
     REQUIRE(r0.status == 200);
     REQUIRE(r1.status == 200);
     REQUIRE(coordinator.is_loaded("a"));
+}
+
+// Regression for issue #28: an in-flight predict_stream must stop promptly when
+// the cancel flag is set (forwarded coordinator -> model), so an aborted turn
+// releases its slot instead of hanging.
+TEST_CASE("predict_stream honors the cancel flag and returns promptly", "[routes][cancel]") {
+    ModelRegistry registry;
+    registry.set_factory([](const ModelInfo& info) {
+        auto m = std::make_unique<IModelMock>(info);
+        m->block_until_cancel.store(true);  // hang until cancelled
+        return m;
+    });
+    registry.register_model(make_info("a"));
+    BackendCoordinator coordinator(registry);
+    REQUIRE(coordinator.load("a"));
+    auto slot = coordinator.acquire_slot("a");
+    REQUIRE(slot);
+
+    std::atomic<bool> cancel{false};
+    std::atomic<bool> done{false};
+    InferenceRequest req;
+    std::thread worker([&]() {
+        (void)coordinator.predict_stream(
+            "a", *slot, req,
+            [](const InferenceDelta&) { return true; }, &cancel);
+        done.store(true);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    REQUIRE_FALSE(done.load());  // still running without a cancel
+
+    cancel.store(true);
+    worker.join();
+    REQUIRE(done.load());
+    REQUIRE(coordinator.release_slot("a", *slot));
 }

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
@@ -79,7 +79,8 @@ public:
       int slot_id, const inferdeck::model::InferenceRequest& req) override;
   inferdeck::foundation::Result<inferdeck::model::InferenceResult> predict_stream(
       int slot_id, const inferdeck::model::InferenceRequest& req,
-      const inferdeck::model::IModel::TokenCallback& callback) override;
+      const inferdeck::model::IModel::TokenCallback& callback,
+      const std::atomic<bool>* cancel = nullptr) override;
 
   static std::string version();
   static void init_backend();
@@ -101,7 +102,8 @@ private:
   inferdeck::model::ModelInfo info_;
   LlamaCppConfig cfg_;
   std::atomic<bool> loaded_{false};
-  mutable std::mutex mtx_;
+  mutable std::mutex mtx_;        // guards model/slot state (acquire/release/status)
+  std::mutex decode_mtx_;         // serializes prefill+decode; NOT held during acquire/status
   llama_model* model_{nullptr};
   const llama_vocab* vocab_{nullptr};
   std::vector<SlotState> slots_;

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -1168,16 +1168,26 @@ Result<InferenceResult> LlamaCppModel::predict(int slot_id, const InferenceReque
     return Result<InferenceResult>(std::unexpect,
         make_error(ErrorCode::InvalidArgument, "slot_id out of range"));
   }
-  std::lock_guard lk(mtx_);
-  if (!loaded_.load()) {
-    return Result<InferenceResult>(std::unexpect,
-        make_error(ErrorCode::Internal, "model not loaded"));
+  SlotState* slot_ptr = nullptr;
+  {
+    std::lock_guard lk(mtx_);
+    if (!loaded_.load()) {
+      return Result<InferenceResult>(std::unexpect,
+          make_error(ErrorCode::Internal, "model not loaded"));
+    }
+    slot_ptr = &slots_[slot_id];
+    if (!slot_ptr->busy || !slot_ptr->ctx) {
+      return Result<InferenceResult>(std::unexpect,
+          make_error(ErrorCode::InvalidArgument, "slot not acquired or no context"));
+    }
   }
-  auto& slot = slots_[slot_id];
-  if (!slot.busy || !slot.ctx) {
-    return Result<InferenceResult>(std::unexpect,
-        make_error(ErrorCode::InvalidArgument, "slot not acquired or no context"));
-  }
+  // Run inference without the state mutex so acquire_slot/release_slot/status
+  // stay responsive during generation; serialize the decode itself since the
+  // backend is not safe for concurrent submission across contexts. The slot is
+  // marked busy (active_requests > 0), so unload() drains before it can be torn
+  // down -- the slot's ctx and last_prompt_tokens are exclusively ours here.
+  std::lock_guard decode_lk(decode_mtx_);
+  auto& slot = *slot_ptr;
 
   auto tmpl_res = apply_chat_template(req);
   if (!tmpl_res.has_value()) {
@@ -1349,21 +1359,30 @@ Result<InferenceResult> LlamaCppModel::predict(int slot_id, const InferenceReque
 }
 
 Result<InferenceResult> LlamaCppModel::predict_stream(
-    int slot_id, const InferenceRequest& req, const TokenCallback& callback) {
+    int slot_id, const InferenceRequest& req, const TokenCallback& callback,
+    const std::atomic<bool>* cancel) {
   if (slot_id < 0 || slot_id >= static_cast<int>(slots_.size())) {
     return Result<InferenceResult>(std::unexpect,
         make_error(ErrorCode::InvalidArgument, "slot_id out of range"));
   }
-  std::lock_guard lk(mtx_);
-  if (!loaded_.load()) {
-    return Result<InferenceResult>(std::unexpect,
-        make_error(ErrorCode::Internal, "model not loaded"));
+  SlotState* slot_ptr = nullptr;
+  {
+    std::lock_guard lk(mtx_);
+    if (!loaded_.load()) {
+      return Result<InferenceResult>(std::unexpect,
+          make_error(ErrorCode::Internal, "model not loaded"));
+    }
+    slot_ptr = &slots_[slot_id];
+    if (!slot_ptr->busy || !slot_ptr->ctx) {
+      return Result<InferenceResult>(std::unexpect,
+          make_error(ErrorCode::InvalidArgument, "slot not acquired or no context"));
+    }
   }
-  auto& slot = slots_[slot_id];
-  if (!slot.busy || !slot.ctx) {
-    return Result<InferenceResult>(std::unexpect,
-        make_error(ErrorCode::InvalidArgument, "slot not acquired or no context"));
-  }
+  // Run inference without the state mutex so acquire_slot/release_slot/status
+  // stay responsive during generation; serialize the decode itself since the
+  // backend is not safe for concurrent submission across contexts.
+  std::lock_guard decode_lk(decode_mtx_);
+  auto& slot = *slot_ptr;
 
   auto tmpl_res = apply_chat_template(req);
   if (!tmpl_res.has_value()) {
@@ -1441,6 +1460,15 @@ Result<InferenceResult> LlamaCppModel::predict_stream(
   bool stopped = false;
   bool truncated = false;
   for (int i = 0; i < max_tokens; ++i) {
+    // Honor an external cancellation request (client aborted / stream torn down)
+    // promptly, even when the token callback is not the abort signal. The first
+    // iteration runs right after prefill, so this also bounds cancel latency for
+    // a request aborted during prompt processing.
+    if (cancel && cancel->load()) {
+      stopped = true;
+      out.finish_reason = "stop";
+      break;
+    }
     const llama_token id = common_sampler_sample(smp, slot.ctx.get(), -1);
     bool is_stop = llama_vocab_is_eog(vocab_, id);
     if (!is_stop) {

--- a/libs/model/include/model/backend_coordinator.hpp
+++ b/libs/model/include/model/backend_coordinator.hpp
@@ -52,7 +52,8 @@ public:
 
     foundation::Result<InferenceResult> predict_stream(
         const std::string& name, int slot_id, const InferenceRequest& req,
-        const IModel::TokenCallback& callback);
+        const IModel::TokenCallback& callback,
+        const std::atomic<bool>* cancel = nullptr);
 
     void drain_active(std::chrono::milliseconds timeout = std::chrono::milliseconds{30000});
     int active_request_count() const;

--- a/libs/model/include/model/imodel.hpp
+++ b/libs/model/include/model/imodel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -118,8 +119,13 @@ public:
     virtual foundation::Result<InferenceResult> predict(
         int slot_id, const InferenceRequest& req) = 0;
 
+    // `cancel`, when non-null and set to true, requests that an in-flight
+    // generation stop as soon as possible (checked between tokens / after
+    // prefill). Defaulted so non-streaming implementations need not override.
     virtual foundation::Result<InferenceResult> predict_stream(
-        int slot_id, const InferenceRequest& req, const TokenCallback& callback) {
+        int slot_id, const InferenceRequest& req, const TokenCallback& callback,
+        const std::atomic<bool>* cancel = nullptr) {
+        (void)cancel;
         return foundation::Err<InferenceResult>(foundation::ErrorCode::Internal,
             "streaming not implemented");
     }

--- a/libs/model/src/backend_coordinator.cpp
+++ b/libs/model/src/backend_coordinator.cpp
@@ -276,7 +276,7 @@ foundation::Result<InferenceResult> BackendCoordinator::predict(
 
 foundation::Result<InferenceResult> BackendCoordinator::predict_stream(
     const std::string& name, int slot_id, const InferenceRequest& req,
-    const IModel::TokenCallback& callback) {
+    const IModel::TokenCallback& callback, const std::atomic<bool>* cancel) {
     IModel* inst = nullptr;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -287,7 +287,7 @@ foundation::Result<InferenceResult> BackendCoordinator::predict_stream(
         }
         inst = it->second.get();
     }
-    return inst->predict_stream(slot_id, req, callback);
+    return inst->predict_stream(slot_id, req, callback, cancel);
 }
 
 void BackendCoordinator::drain_active(std::chrono::milliseconds timeout) {


### PR DESCRIPTION
## Problem
`LlamaCppModel::predict`/`predict_stream` held the per-model `mtx_` for the **entire** generation, and the same `mtx_` guards `acquire_slot`/`release_slot`/`slot_busy`/status. So a long or stuck request froze slot acquisition and `/api/status`, and an in-flight stream had no cancellation path beyond the token callback. Confirmed from OpenCode's client log: a turn after a file read hung ~7 minutes until the user cancelled, and `stop`/`continue` couldn't recover.

## Fix
- **Don't hold `mtx_` across decode.** Validate and capture the slot under a brief `mtx_` lock, then run prefill + decode under a dedicated `decode_mtx_` with `mtx_` released. `acquire_slot`/`release_slot`/status stay responsive during generation. The slot stays `busy` (active_requests > 0), so `unload()` drains before the ctx can be torn down — the slot's ctx/last_prompt_tokens are exclusively ours during the call.
- **Dedicated decode mutex, not per-slot.** Decode stays serialized because the ggml/Vulkan backend is not known-safe for concurrent submission across separate contexts. This delivers issue #28's goal (unblock acquire/status/cancel) without risking concurrent GPU submission. Enabling true cross-slot concurrency is a separate follow-up gated on backend thread-safety.
- **Real cancellation.** Optional `const std::atomic<bool>* cancel` threaded through `IModel` / `BackendCoordinator` / `LlamaCppModel` `predict_stream` (defaulted, so non-streaming impls/mocks need no change). The decode loop checks it each iteration; the first iteration runs right after prefill, bounding cancel latency for a request aborted during prompt processing. OpenAI and Anthropic stream handlers pass `&StreamState::aborted`.

## Tests
`route_tests` adds a cancel-contract test: a mock `predict_stream` that blocks until cancelled returns promptly once the flag is set (forwarded coordinator → model). Full `ctest -L "unit|integration"` green (6/6); `llama_cpp_model_tests` green (13/13).

## Verification note
The mutex/cancel restructure is covered by unit tests at the mock/coordinator level and by compile + existing llama wrapper tests; **real-generation behavior is verified live at deploy** (a real OpenCode agent turn — large prompt + file read — should complete without the multi-minute hang, and an aborted turn should free the slot immediately).

Fixes #28