### PR TITLE
Fix VRAM leak when model context init fails mid-slot (#31)

### DIFF
--- a/config/gateway.yml
+++ b/config/gateway.yml
@@ -78,7 +78,7 @@ model_registry:
     family: "qwen3.6"
     gguf_path: "C:/Inferdeck/models/DevQuasar/Qwen.Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen.Qwen3-Coder-30B-A3B-Instruct.Q4_K_M.gguf"
     mmproj_path: ""
-    n_slots: 2
+    n_slots: 1
     vram_required_mb: 20000
     context_size: 262144
     has_vision: false

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -759,9 +759,22 @@ LlamaCppModel::LlamaCppModel(inferdeck::model::ModelInfo info, LlamaCppConfig cf
 }
 
 LlamaCppModel::~LlamaCppModel() {
-  if (loaded_.load()) {
-    (void)unload();
+  std::lock_guard lk(mtx_);
+  for (auto& s : slots_) {
+    s.ctx.reset();
+    s.busy = false;
   }
+  slots_.clear();
+  if (chat_templates_) {
+    common_chat_templates_free(chat_templates_);
+    chat_templates_ = nullptr;
+  }
+  if (model_) {
+    llama_model_free(model_);
+    model_ = nullptr;
+  }
+  vocab_ = nullptr;
+  loaded_.store(false);
 }
 
 Result<void> LlamaCppModel::load() {
@@ -832,6 +845,11 @@ Result<void> LlamaCppModel::load() {
   }
   auto ctx_res = init_contexts_locked();
   if (!ctx_res.has_value()) {
+    for (auto& s : slots_) {
+      s.ctx.reset();
+      s.busy = false;
+    }
+    slots_.clear();
     llama_model_free(model_);
     model_ = nullptr;
     return ctx_res;


### PR DESCRIPTION
## Summary

- Free partially-created slot contexts in `load()` error path — previously only `model_` was freed when `init_contexts_locked()` failed, leaving any already-created slot contexts allocated on the GPU
- Rewrite `~LlamaCppModel()` destructor to unconditionally clean up all resources regardless of `loaded_` state, closing the secondary leak path if an instance is dropped without going through `unload()`
- Set `qwen3-coder-30b-a3b` to `n_slots: 1` in `config/gateway.yml` — 2 slots at 262144 context cannot fit in 32 GB VRAM alongside model weights and reliably trigger this path

## Root cause (observed in production today)

`qwen3-coder-30b-a3b` OOM'd on slot 1 (262K × 2 slots > 32 GB), leaving slot 0's context (~14 GB) allocated. The next model loaded (`qwen3.6-35b-a3b`) then overflowed VRAM with that residual allocation still present, dropping TPS from ~155 t/s to ~20 t/s for the rest of the session.

Closes #31

## Test plan

- [x] Load `qwen3-coder-30b-a3b` then swap to `qwen3.6-35b-a3b` — confirm `gpu_local_mb` before the second load is near-zero (not ~14 GB)
- [x] Confirm `qwen3.6-35b-a3b` sustained TPS remains ~150+ t/s after the swap
- [ ] Confirm `qwen3-coder-30b-a3b` loads without OOM with `n_slots: 1`