### PR TITLE
fix: history-aware prompt truncation and raised context sizes (#38, #40)

### DIFF
--- a/config/gateway.yml
+++ b/config/gateway.yml
@@ -61,8 +61,8 @@ model_registry:
     gguf_path: "C:/Inferdeck/models/unsloth/Qwen3.6-27B-GGUF/Qwen3.6-27B-Q4_K_M.gguf"
     mmproj_path: "C:/Inferdeck/models/unsloth/Qwen3.6-27B-GGUF/mmproj-BF16.gguf"
     n_slots: 3
-    vram_required_mb: 20000
-    context_size: 32768
+    vram_required_mb: 31000
+    context_size: 40960
     has_vision: true
 
   - name: "qwen3.6-35b-a3b"
@@ -88,8 +88,8 @@ model_registry:
     gguf_path: "C:/Inferdeck/models/unsloth/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-UD-Q2_K_XL.gguf"
     mmproj_path: null
     n_slots: 1
-    vram_required_mb: 30000
-    context_size: 32768
+    vram_required_mb: 29000
+    context_size: 262144
     has_vision: false
 
   - name: "qwen2.5-coder-3b"

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
@@ -99,8 +99,11 @@ private:
   inferdeck::foundation::Result<void> init_shared_context_locked();
   inferdeck::foundation::Result<void> build_sampler_locked(
       llama_sampler** out, const inferdeck::model::InferenceRequest& req);
+  // max_prompt_tokens > 0 enables history-aware truncation: oldest whole
+  // non-system messages are dropped (preserving recency + coherence) until the
+  // templated prompt fits the budget. 0 disables truncation.
   inferdeck::foundation::Result<ChatTemplateResult> apply_chat_template(
-      const inferdeck::model::InferenceRequest& req);
+      const inferdeck::model::InferenceRequest& req, int max_prompt_tokens = 0);
 
   // Per-inference setup: tokenize, KV-state snapshot, sampler construction.
   struct PredictSetup {

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -179,7 +179,11 @@ static bool maybe_truncate_prompt(
     const std::string& model_name) {
   const int n_tokens = static_cast<int>(prompt_tokens.size());
   if (n_tokens < n_ctx) return false;
-  const int reserve = std::clamp(req_max_tokens > 0 ? req_max_tokens : 1024, 256, n_ctx / 4);
+  // Guard the clamp bounds: when n_ctx < 1024 the upper bound (n_ctx/4) falls
+  // below 256, so std::clamp(x, 256, hi) would have lo > hi, which is UB.
+  const int reserve_hi = n_ctx / 4;
+  const int reserve = std::clamp(req_max_tokens > 0 ? req_max_tokens : 1024,
+                                 std::min(256, reserve_hi), reserve_hi);
   const int target = n_ctx - reserve - 1;
   const int keep_head = std::min(1024, target / 4);
   const int keep_tail = target - keep_head;
@@ -1044,7 +1048,7 @@ Result<void> LlamaCppModel::reset_all_slots() noexcept {
 }
 
 Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
-    const InferenceRequest& req) {
+    const InferenceRequest& req, int max_prompt_tokens) {
   if (!chat_templates_) {
     return Result<ChatTemplateResult>(std::unexpect, make_error(ErrorCode::Internal, "chat templates not initialized"));
   }
@@ -1150,6 +1154,42 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
   try {
   auto chat_params = common_chat_templates_apply(chat_templates_, inputs);
 
+  // History-aware truncation (issue #38): rather than middle-dropping the raw
+  // token stream (which severs conversation history and defeats KV prefix
+  // reuse), drop the oldest *whole* non-system messages and re-template until
+  // the prompt fits the budget. The leading system block and the most recent
+  // turn are always preserved.
+  if (max_prompt_tokens > 0) {
+    auto count_prompt_tokens = [&](const std::string& p) -> int {
+      if (p.empty()) return 0;
+      const int n = llama_tokenize(vocab_, p.data(), static_cast<int>(p.size()),
+                                   nullptr, 0, llama_vocab_get_add_bos(vocab_), true);
+      return n < 0 ? -n : n;
+    };
+    std::size_t sys_end = 0;
+    while (sys_end < inputs.messages.size() && inputs.messages[sys_end].role == "system")
+      ++sys_end;
+    int dropped = 0;
+    while (count_prompt_tokens(chat_params.prompt) >= max_prompt_tokens &&
+           inputs.messages.size() - sys_end > 1) {
+      inputs.messages.erase(inputs.messages.begin() + static_cast<std::ptrdiff_t>(sys_end));
+      ++dropped;
+      // Drop any now-orphaned tool results whose assistant tool_call was removed.
+      while (inputs.messages.size() - sys_end > 1 &&
+             inputs.messages[sys_end].role == "tool") {
+        inputs.messages.erase(inputs.messages.begin() + static_cast<std::ptrdiff_t>(sys_end));
+        ++dropped;
+      }
+      chat_params = common_chat_templates_apply(chat_templates_, inputs);
+    }
+    if (dropped > 0) {
+      LOG_WARN("chat_history_truncated",
+               "model={} dropped_messages={} kept_messages={} prompt_tokens={} budget={}",
+               info_.name, dropped, inputs.messages.size(),
+               count_prompt_tokens(chat_params.prompt), max_prompt_tokens);
+    }
+  }
+
   ChatTemplateMeta meta;
   meta.thinking_start_tag = chat_params.thinking_start_tag;
   meta.thinking_end_tag = chat_params.thinking_end_tag;
@@ -1247,7 +1287,21 @@ Result<void> LlamaCppModel::build_sampler_locked(
 Result<LlamaCppModel::PredictSetup> LlamaCppModel::prepare_inference(
     int slot_id, const InferenceRequest& req) {
   PredictSetup s;
-  auto tmpl_res = apply_chat_template(req);
+  // Compute the prompt-token budget so apply_chat_template can drop whole
+  // oldest messages (history-aware truncation, issue #38) before tokenizing.
+  // Mirrors the reserve/target maths in maybe_truncate_prompt, which remains as
+  // a hard safety net for the pathological single-oversized-message case.
+  const int n_ctx_seq = static_cast<int>(llama_n_ctx_seq(shared_ctx_));
+  int budget = 0;
+  if (cfg_.truncate_prompt && n_ctx_seq > 0) {
+    // See maybe_truncate_prompt: clamp bounds must satisfy lo <= hi (UB
+    // otherwise) when n_ctx_seq < 1024.
+    const int reserve_hi = n_ctx_seq / 4;
+    const int reserve = std::clamp(req.max_tokens > 0 ? req.max_tokens : 1024,
+                                   std::min(256, reserve_hi), reserve_hi);
+    budget = n_ctx_seq - reserve - 1;
+  }
+  auto tmpl_res = apply_chat_template(req, budget);
   if (!tmpl_res.has_value())
     return Result<PredictSetup>(std::unexpect, tmpl_res.error());
 


### PR DESCRIPTION
## Summary
Fixes #38 and #40.

### #38 — History-aware prompt truncation
`maybe_truncate_prompt()` previously kept the head + tail and **discarded the middle of the prompt** (the conversation history), causing incoherent answers after a few tool-call rounds and defeating KV prefix reuse.

This adds history-aware truncation in `apply_chat_template`: when a prompt-token budget is set, drop the **oldest whole non-system messages** (and any now-orphaned `tool` results whose assistant turn was removed) and re-template until the prompt fits. The leading system block and the most recent turn are always preserved. `maybe_truncate_prompt` remains as a hard safety net for the pathological single-oversized-message case.

### #40 — Raise context sizes
- `qwen3-coder-next`: 32768 -> **262144** (native)
- `qwen3.6-27b`: 32768 -> **40960**
- `vram_required_mb` adjusted accordingly.

### Hardening
Guards the reserve `std::clamp` in both `apply_chat_template` and `maybe_truncate_prompt` so the low bound never exceeds the high bound when `n_ctx < 1024` (avoids `std::clamp` UB).

## Testing
- Built Release locally and ran from the build dir.
- Observed live: an 18,489-token prompt served at `n_ctx=40960` with `truncated=false`, and KV prefix reuse hitting (`cached_tokens=18637`).

## Notes for review
- `qwen3-coder-next` `vram_required_mb` was **lowered** to 29000 while context grew 8x — please confirm this is a measured value before merge; KV cache at 262144 is large on the 32GB card.
- Unrelated to this PR: the gateway currently force-applies DRY + repeat_penalty server-side (diverges from llama-server); tracked separately as a new feature issue.