### PR TITLE
fix: scheduler KV-reuse context loss breaking multi-turn tool calls (#43)

### DIFF
--- a/libs/llama_cpp_wrapper/src/continuous_batch_scheduler.cpp
+++ b/libs/llama_cpp_wrapper/src/continuous_batch_scheduler.cpp
@@ -85,37 +85,39 @@ void ContinuousBatchScheduler::init_task(SlotTask* task) {
         return;
     }
 
-    // Check against what is actually in the cache
-    const auto pos_max = llama_memory_seq_pos_max(mem, seq_id);
-    if (n_past > pos_max) {
-        // Cache has fewer tokens than the common prefix; use what is there
-        task->prompt_pos = n_past;
-        task->n_pos = n_past;
-        task->out_cached_prompt_tokens = n_past;
-        LOG_INFO("scheduler_kv_reuse",
-                 "slot={} cached_tokens={} prompt_tokens={}",
-                 seq_id, n_past, (int)task->prompt_tokens.size());
+    // Only reuse what is *physically* present in this slot's KV cache. The
+    // cached token arrays (last_prompt_tokens) can claim a longer common
+    // prefix than the cache actually holds — after a prior turn evicted
+    // entries, or with a SWA cache. Skipping past the real cache contents
+    // would decode the tail against an empty KV and silently drop the earlier
+    // context (system prompt, tool definitions, history) — see issue #43.
+    const int pos_max = static_cast<int>(llama_memory_seq_pos_max(mem, seq_id));
+    n_past = std::min(n_past, pos_max + 1);
+    if (n_past <= 0) {
+        llama_memory_seq_rm(mem, seq_id, 0, -1);
+        task->prompt_pos = 0;
+        task->n_pos = 0;
+        task->out_cached_prompt_tokens = 0;
         return;
     }
 
-    // Trim the cache to keep positions 0..n_past-1
-    if (llama_memory_seq_rm(mem, seq_id, n_past, -1)) {
-        task->prompt_pos = n_past;
-        task->n_pos = n_past;
-        task->out_cached_prompt_tokens = n_past;
-        LOG_INFO("scheduler_kv_reuse",
-                 "slot={} cached_tokens={} prompt_tokens={}",
-                 seq_id, n_past, (int)task->prompt_tokens.size());
+    // Trim any cached tokens beyond the reused prefix, then decode the rest.
+    if (!llama_memory_seq_rm(mem, seq_id, n_past, -1)) {
+        // seq_rm failed (e.g. SWA cache): clear this slot and start fresh.
+        LOG_WARN("scheduler_kv_clear",
+                 "slot={} seq_rm_failed clearing slot sequence", seq_id);
+        llama_memory_seq_rm(mem, seq_id, 0, -1);
+        task->prompt_pos = 0;
+        task->n_pos = 0;
+        task->out_cached_prompt_tokens = 0;
         return;
     }
-
-    // seq_rm failed (e.g. SWA cache): clear this slot and start fresh
-    LOG_WARN("scheduler_kv_clear",
-             "slot={} seq_rm_failed clearing slot sequence", seq_id);
-    llama_memory_seq_rm(mem, seq_id, 0, -1);
-    task->prompt_pos = 0;
-    task->n_pos = 0;
-    task->out_cached_prompt_tokens = 0;
+    task->prompt_pos = n_past;
+    task->n_pos = n_past;
+    task->out_cached_prompt_tokens = n_past;
+    LOG_INFO("scheduler_kv_reuse",
+             "slot={} cached_tokens={} prompt_tokens={}",
+             seq_id, n_past, (int)task->prompt_tokens.size());
 }
 
 void ContinuousBatchScheduler::run_loop() {
@@ -300,12 +302,14 @@ void ContinuousBatchScheduler::run_loop() {
             }
         }
 
-        // Remove completed slots and clear their KV entries
+        // Remove completed slots from the active set, but keep their KV cache
+        // intact so the next request on this slot can reuse the shared prefix
+        // (init_task trims any divergent suffix). Wiping here forces a full
+        // re-decode every turn and, with init_task's prefix assumptions, drops
+        // conversation context — the root cause of issue #43.
         if (!completed.empty()) {
-            auto* mem = llama_get_memory(ctx_);
             std::lock_guard lk(sub_mtx_);
             for (auto* t : completed) {
-                if (mem) llama_memory_seq_rm(mem, t->slot_id, 0, -1);
                 active_.erase(std::remove(active_.begin(), active_.end(), t), active_.end());
             }
         }


### PR DESCRIPTION
Closes #43.

## Problem
Since continuous batching (#37), multi-turn agentic tool-calling broke: the model makes the first tool call, then on later turns hallucinates or emits malformed calls instead of using tools. Confirmed by A/B bisect — the pre-continuous-batching v0.1.1 binary is stable with the *same* model/config/llama.cpp; the continuous-batching build is not.

## Root cause
`ContinuousBatchScheduler` desynced the KV cache from the prompt `init_task` assumed was cached:
1. The slot's KV was wiped on completion (`llama_memory_seq_rm(mem, slot_id, 0, -1)`).
2. `init_task` then skipped re-decoding the full common prefix (`prompt_pos = n_past`) instead of only what the cache physically held.

From turn 2+ on a reused slot the model decoded only the tail against an empty KV, losing the system prompt + tool definitions, so it stopped emitting the `<tool_call>` opener and the lazy grammar never fired.

## Fix
- `init_task`: clamp reuse to `pos_max + 1` (never skip past what's physically cached), then decode the remainder.
- Keep slot KV intact on successful completion so prefix reuse is valid and fast (matches stock llama-server). Cancel-path clear retained; the clamp keeps it correct.

## Verification
Built off `main` (continuous batching retained). Deployed and tested on a real OpenCode session:
- Standard multi-step file read (`about.jsx`) — reads in one step, truthful answer.
- Advanced MCP session — Playwright navigate → snapshot → 4x WebFetch → synthesis, all tool calls reliable.

Both stable, matching the v0.1.1 baseline, with continuous batching on.

Related: #39 (symptom), #37 (introduced continuous batching).