### PR TITLE
feat: server-side configurable sampling with per-model overrides (#42)

### DIFF
--- a/apps/inferdeck-gateway/src/config.hpp
+++ b/apps/inferdeck-gateway/src/config.hpp
@@ -40,8 +40,30 @@ struct GatewayConfig {
     std::string cache_type_v{"q8_0"};
     bool swa_full{false};
     bool truncate_prompt{true};
+    model::SamplingConfig sampling{};  // global sampler defaults (issue #42)
     std::map<std::string, std::string> anthropic_model_aliases{};
 };
+
+// Overlay any sampler keys present in `node` onto `s` (keys left unspecified
+// keep their current value, so per-model blocks inherit the global defaults).
+inline void parse_sampling(const YAML::Node& node, model::SamplingConfig& s) {
+    if (!node || !node.IsMap()) return;
+    if (node["temperature"]) s.temperature = node["temperature"].as<float>();
+    if (node["top_p"]) s.top_p = node["top_p"].as<float>();
+    if (node["top_k"]) s.top_k = node["top_k"].as<int>();
+    if (node["min_p"]) s.min_p = node["min_p"].as<float>();
+    if (node["repeat_penalty"]) s.repeat_penalty = node["repeat_penalty"].as<float>();
+    if (node["repeat_last_n"]) s.repeat_last_n = node["repeat_last_n"].as<int>();
+    if (node["dry_multiplier"]) s.dry_multiplier = node["dry_multiplier"].as<float>();
+    if (node["dry_base"]) s.dry_base = node["dry_base"].as<float>();
+    if (node["dry_allowed_length"]) s.dry_allowed_length = node["dry_allowed_length"].as<int>();
+    if (node["dry_penalty_last_n"]) s.dry_penalty_last_n = node["dry_penalty_last_n"].as<int>();
+    if (node["dry_seq_breakers"] && node["dry_seq_breakers"].IsSequence()) {
+        s.dry_seq_breakers.clear();
+        for (const auto& b : node["dry_seq_breakers"])
+            s.dry_seq_breakers.push_back(b.as<std::string>());
+    }
+}
 
 inline std::string read_text_file(const std::filesystem::path& path) {
     std::ifstream f(path, std::ios::binary);
@@ -122,6 +144,7 @@ inline GatewayConfig load_config(const std::filesystem::path& path) {
         if (g["cache_type_v"]) cfg.cache_type_v = g["cache_type_v"].as<std::string>();
         if (g["swa_full"]) cfg.swa_full = g["swa_full"].as<bool>();
         if (g["truncate_prompt"]) cfg.truncate_prompt = g["truncate_prompt"].as<bool>();
+        if (g["sampling"]) parse_sampling(g["sampling"], cfg.sampling);
     }
     if (root["anthropic"] && root["anthropic"]["model_aliases"] &&
         root["anthropic"]["model_aliases"].IsMap()) {
@@ -149,6 +172,10 @@ inline GatewayConfig load_config(const std::filesystem::path& path) {
             }
             info.has_vision = m["has_vision"] ? m["has_vision"].as<bool>() : false;
             info.reasoning_format = m["reasoning_format"] ? m["reasoning_format"].as<std::string>() : "";
+            // Per-model sampling overrides inherit the global block, then apply
+            // any keys present in this entry (issue #42).
+            info.sampling = cfg.sampling;
+            if (m["sampling"]) parse_sampling(m["sampling"], info.sampling);
             cfg.models.push_back(std::move(info));
         }
     }

--- a/apps/inferdeck-gateway/src/main.cpp
+++ b/apps/inferdeck-gateway/src/main.cpp
@@ -277,6 +277,7 @@ int main(int argc, char** argv) {
         lc.swa_full = cfg.swa_full;
         lc.truncate_prompt = cfg.truncate_prompt;
         lc.reasoning_format = info.reasoning_format.empty() ? "auto" : info.reasoning_format;
+        lc.sampling = info.sampling;  // per-model merged over global (issue #42)
         return std::make_unique<llama_wrapper::LlamaCppModel>(info, lc);
     });
     for (const auto& m : cfg.models) {

--- a/config/gateway.yml
+++ b/config/gateway.yml
@@ -39,6 +39,23 @@ gateway:
   swa_full: false
   truncate_prompt: true
 
+  # Server-side sampler defaults (issue #42). These mirror stock llama-server:
+  # DRY off and repeat_penalty neutral, so reasoning models (Qwen3 / Qwen3.6)
+  # stay coherent. Explicit per-request (OpenAI body) values still override
+  # these. Can be overridden per entry under model_registry below.
+  sampling:
+    temperature: 0.8
+    top_p: 0.95
+    top_k: 40
+    min_p: 0.05
+    repeat_penalty: 1.0      # 1.0 = disabled (llama-server default)
+    repeat_last_n: 64
+    dry_multiplier: 0.0      # 0.0 = disabled (llama-server default)
+    dry_base: 1.75
+    dry_allowed_length: 2
+    dry_penalty_last_n: -1   # -1 = context size
+    dry_seq_breakers: ["\n", ":", "\"", "*"]
+
 # Map Anthropic model names to local models so Anthropic-API clients
 # (e.g. Claude Code) route to the right local model. Unmapped names fall back
 # to the loaded model, then default_model. Keys must be the exact model IDs the
@@ -64,6 +81,16 @@ model_registry:
     vram_required_mb: 31000
     context_size: 40960
     has_vision: true
+    # Per-model sampler overrides inherit the global `gateway.sampling` block
+    # above and override only the keys listed here (issue #42).
+    # Qwen3 thinking/reasoning sweet spot (Qwen team): temp 0.6, top_p 0.95,
+    # top_k 20, min_p 0, no repetition penalty / no DRY.
+    sampling:
+      temperature: 0.6
+      top_p: 0.95
+      top_k: 20
+      min_p: 0.0
+      repeat_penalty: 1.0
 
   - name: "qwen3.6-35b-a3b"
     family: "qwen3.6"
@@ -73,6 +100,13 @@ model_registry:
     vram_required_mb: 24000
     context_size: 100096
     has_vision: false
+    # Qwen3 thinking/reasoning sweet spot (Qwen team).
+    sampling:
+      temperature: 0.6
+      top_p: 0.95
+      top_k: 20
+      min_p: 0.0
+      repeat_penalty: 1.0
 
   - name: "qwen3-coder-30b-a3b"
     family: "qwen3.6"
@@ -82,6 +116,14 @@ model_registry:
     vram_required_mb: 20000
     context_size: 262144
     has_vision: false
+    # Qwen3-Coder recommended sampling (Qwen team): temp 0.7, top_p 0.8,
+    # top_k 20, repetition_penalty 1.05.
+    sampling:
+      temperature: 0.7
+      top_p: 0.8
+      top_k: 20
+      min_p: 0.0
+      repeat_penalty: 1.05
 
   - name: "qwen3-coder-next"
     family: "qwen3-next"
@@ -91,6 +133,13 @@ model_registry:
     vram_required_mb: 29000
     context_size: 262144
     has_vision: false
+    # Qwen3-Coder recommended sampling (Qwen team).
+    sampling:
+      temperature: 0.7
+      top_p: 0.8
+      top_k: 20
+      min_p: 0.0
+      repeat_penalty: 1.05
 
   - name: "qwen2.5-coder-3b"
     family: "qwen2.5"
@@ -100,6 +149,14 @@ model_registry:
     vram_required_mb: 2500
     context_size: 32768
     has_vision: false
+    # Qwen2.5 recommended generation config: temp 0.7, top_p 0.8, top_k 20,
+    # repetition_penalty 1.05.
+    sampling:
+      temperature: 0.7
+      top_p: 0.8
+      top_k: 20
+      min_p: 0.0
+      repeat_penalty: 1.05
 
   - name: "gemma-4-26b-a4b"
     family: "gemma4"
@@ -109,6 +166,14 @@ model_registry:
     vram_required_mb: 13000
     context_size: 32768
     has_vision: true
+    # Gemma recommended sampling (Google): temp 1.0, top_k 64, top_p 0.95,
+    # min_p 0.
+    sampling:
+      temperature: 1.0
+      top_p: 0.95
+      top_k: 64
+      min_p: 0.0
+      repeat_penalty: 1.0
 
   - name: "gpt-oss-20b"
     family: "gpt-oss"
@@ -118,3 +183,11 @@ model_registry:
     vram_required_mb: 13000
     context_size: 32768
     has_vision: false
+    # gpt-oss recommended sampling (OpenAI): temp 1.0, top_p 1.0, top_k disabled,
+    # min_p 0. Repetition controls off.
+    sampling:
+      temperature: 1.0
+      top_p: 1.0
+      top_k: 0
+      min_p: 0.0
+      repeat_penalty: 1.0

--- a/libs/gateway/src/anthropic_routes.cpp
+++ b/libs/gateway/src/anthropic_routes.cpp
@@ -166,9 +166,14 @@ model::InferenceRequest make_inference_request_from(const nlohmann::json& openai
     model::InferenceRequest ir;
     ir.openai_body_json = openai_body.dump();
     ir.max_tokens = openai_body.value("max_tokens", -1);
-    ir.temperature = static_cast<float>(openai_body.value("temperature", 0.7));
-    ir.top_p = static_cast<float>(openai_body.value("top_p", 0.95));
-    ir.top_k = openai_body.value("top_k", 40);
+    // Only carry sampler params the client explicitly set; unset ones fall back
+    // to the server-side SamplingConfig defaults downstream (issue #42).
+    if (openai_body.contains("temperature") && !openai_body["temperature"].is_null())
+        ir.temperature = openai_body["temperature"].get<float>();
+    if (openai_body.contains("top_p") && !openai_body["top_p"].is_null())
+        ir.top_p = openai_body["top_p"].get<float>();
+    if (openai_body.contains("top_k") && !openai_body["top_k"].is_null())
+        ir.top_k = openai_body["top_k"].get<int>();
     return ir;
 }
 

--- a/libs/gateway/src/routes.cpp
+++ b/libs/gateway/src/routes.cpp
@@ -245,11 +245,18 @@ model::InferenceRequest make_inference_request(const nlohmann::json& body) {
     model::InferenceRequest ir;
     ir.openai_body_json = body.dump();
     ir.max_tokens = body.value("max_tokens", body.value("max_completion_tokens", -1));
-    ir.temperature = static_cast<float>(body.value("temperature", 0.7));
-    ir.top_p = static_cast<float>(body.value("top_p", 0.95));
-    ir.top_k = body.value("top_k", 40);
-    ir.repeat_penalty = static_cast<float>(body.value("repeat_penalty", 1.1));
-    ir.repeat_last_n = body.value("repeat_last_n", 64);
+    // Only carry sampler params the client explicitly set; unset ones fall back
+    // to the server-side SamplingConfig defaults downstream (issue #42).
+    if (body.contains("temperature") && !body["temperature"].is_null())
+        ir.temperature = body["temperature"].get<float>();
+    if (body.contains("top_p") && !body["top_p"].is_null())
+        ir.top_p = body["top_p"].get<float>();
+    if (body.contains("top_k") && !body["top_k"].is_null())
+        ir.top_k = body["top_k"].get<int>();
+    if (body.contains("repeat_penalty") && !body["repeat_penalty"].is_null())
+        ir.repeat_penalty = body["repeat_penalty"].get<float>();
+    if (body.contains("repeat_last_n") && !body["repeat_last_n"].is_null())
+        ir.repeat_last_n = body["repeat_last_n"].get<int>();
     ir.seed = body.value("seed", -1);
     return ir;
 }

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
@@ -49,6 +49,7 @@ struct LlamaCppConfig {
   bool truncate_prompt{true};
   std::string chat_template{};
   std::string reasoning_format{};  // "auto", "deepseek", "deepseek_legacy", "none"
+  inferdeck::model::SamplingConfig sampling{};  // server-side sampler defaults (issue #42)
 };
 
 class LlamaCppModel final : public inferdeck::model::IModel {
@@ -97,8 +98,6 @@ private:
   };
 
   inferdeck::foundation::Result<void> init_shared_context_locked();
-  inferdeck::foundation::Result<void> build_sampler_locked(
-      llama_sampler** out, const inferdeck::model::InferenceRequest& req);
   // max_prompt_tokens > 0 enables history-aware truncation: oldest whole
   // non-system messages are dropped (preserving recency + coherence) until the
   // templated prompt fits the budget. 0 disables truncation.

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -1101,6 +1101,28 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
     }
   }
 
+  // DEBUG: log incoming request shape so we can compare OpenCode vs direct Ollama.
+  {
+    std::size_t sys_chars = 0, user_chars = 0, tool_result_chars = 0;
+    int n_sys = 0, n_user = 0, n_assistant = 0, n_tool = 0;
+    for (const auto& m : inputs.messages) {
+      const std::size_t len = m.content.size();
+      if (m.role == "system")    { ++n_sys; sys_chars += len; }
+      else if (m.role == "user") { ++n_user; user_chars += len; }
+      else if (m.role == "assistant") { ++n_assistant; }
+      else if (m.role == "tool") { ++n_tool; tool_result_chars += len; }
+    }
+    const int n_tools_defined = body.contains("tools") && body["tools"].is_array()
+                                  ? static_cast<int>(body["tools"].size()) : 0;
+    const int max_tok = body.value("max_tokens", -1);
+    LOG_INFO("request_shape",
+             "model={} msgs={} [sys={} sys_chars={} user={} asst={} tool_results={} tool_result_chars={}] "
+             "tools_defined={} max_tokens={}",
+             info_.name, inputs.messages.size(),
+             n_sys, sys_chars, n_user, n_assistant, n_tool, tool_result_chars,
+             n_tools_defined, max_tok);
+  }
+
   if (body.contains("tools") && body["tools"].is_array()) {
     try {
       inputs.tools = common_chat_tools_parse_oaicompat(body["tools"]);
@@ -1215,12 +1237,42 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
       }
     }
   }
-  result.sampling_params.temp = req.temperature;
-  result.sampling_params.top_p = req.top_p;
-  result.sampling_params.top_k = req.top_k;
-  result.sampling_params.penalty_repeat = req.repeat_penalty;
-  result.sampling_params.penalty_last_n = req.repeat_last_n;
+  // Sampler params: explicit per-request (OpenAI body) values win; otherwise
+  // fall back to the server-side SamplingConfig defaults (issue #42), which
+  // mirror stock llama-server (DRY off, repeat_penalty neutral).
+  const auto& sc = cfg_.sampling;
+  result.sampling_params.temp          = req.temperature.value_or(sc.temperature);
+  result.sampling_params.top_p         = req.top_p.value_or(sc.top_p);
+  result.sampling_params.top_k         = req.top_k.value_or(sc.top_k);
+  result.sampling_params.min_p         = sc.min_p;
+  result.sampling_params.penalty_repeat = req.repeat_penalty.value_or(sc.repeat_penalty);
+  result.sampling_params.penalty_last_n = req.repeat_last_n.value_or(sc.repeat_last_n);
+  result.sampling_params.dry_multiplier     = sc.dry_multiplier;
+  result.sampling_params.dry_base           = sc.dry_base;
+  result.sampling_params.dry_allowed_length = sc.dry_allowed_length;
+  result.sampling_params.dry_penalty_last_n = sc.dry_penalty_last_n;
+  result.sampling_params.dry_sequence_breakers = sc.dry_seq_breakers;
   result.sampling_params.seed = req.seed >= 0 ? static_cast<std::uint32_t>(req.seed) : LLAMA_DEFAULT_SEED;
+
+  // DEBUG (issue #42 diagnosis): log what the client sent vs what was resolved,
+  // so we can see whether OpenCode/Claude Code override the server-side config.
+  auto opt_f = [](const std::optional<float>& v) {
+    return v.has_value() ? std::to_string(*v) : std::string("unset");
+  };
+  auto opt_i = [](const std::optional<int>& v) {
+    return v.has_value() ? std::to_string(*v) : std::string("unset");
+  };
+  LOG_INFO("sampling_resolved",
+           "model={} client[temp={} top_p={} top_k={} repeat_penalty={} repeat_last_n={}] "
+           "resolved[temp={:.3f} top_p={:.3f} top_k={} min_p={:.3f} repeat_penalty={:.3f} "
+           "repeat_last_n={} dry_mult={:.3f}]",
+           info_.name, opt_f(req.temperature), opt_f(req.top_p), opt_i(req.top_k),
+           opt_f(req.repeat_penalty), opt_i(req.repeat_last_n),
+           result.sampling_params.temp, result.sampling_params.top_p,
+           result.sampling_params.top_k, result.sampling_params.min_p,
+           result.sampling_params.penalty_repeat, result.sampling_params.penalty_last_n,
+           result.sampling_params.dry_multiplier);
+
   if (!chat_params.grammar.empty()) {
     if (!inputs.tools.empty() && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
       result.sampling_params.grammar = {COMMON_GRAMMAR_TYPE_TOOL_CALLS, chat_params.grammar};
@@ -1245,40 +1297,6 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
     return Result<ChatTemplateResult>(std::unexpect,
         make_error(ErrorCode::ParseError, std::string("chat template failed: ") + e.what()));
   }
-}
-
-Result<void> LlamaCppModel::build_sampler_locked(
-    llama_sampler** out, const InferenceRequest& req) {
-  const std::uint32_t seed = req.seed >= 0 ? static_cast<std::uint32_t>(req.seed)
-                                           : static_cast<std::uint32_t>(0xFFFFFFFFu);
-  llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
-  llama_sampler* chain = llama_sampler_chain_init(sparams);
-  if (chain == nullptr) {
-    return Result<void>(std::unexpect, make_error(ErrorCode::Internal, "llama_sampler_chain_init returned null"));
-  }
-  auto append = [&](llama_sampler* s) {
-    if (s) llama_sampler_chain_add(chain, s);
-  };
-
-  const char* dry_seq_breakers[] = {"\n", ":", "\"", "*"};
-  append(llama_sampler_init_dry(
-      vocab_, llama_model_n_ctx_train(model_),
-      0.8f,    // dry_multiplier
-      1.75f,   // dry_base
-      2,       // dry_allowed_length
-      1024,    // dry_penalty_last_n
-      dry_seq_breakers, 4));
-
-  append(llama_sampler_init_penalties(
-      req.repeat_last_n, req.repeat_penalty, 0.0f, 0.0f));
-
-  append(llama_sampler_init_top_k(static_cast<int32_t>(req.top_k)));
-  append(llama_sampler_init_top_p(req.top_p, 1));
-  append(llama_sampler_init_min_p(0.05f, 1));
-  append(llama_sampler_init_temp(req.temperature));
-  append(llama_sampler_init_dist(seed));
-  *out = chain;
-  return Result<void>{};
 }
 
 // Tokenizes the request, checks context limits, snapshots per-slot KV state,

--- a/libs/model/include/model/imodel.hpp
+++ b/libs/model/include/model/imodel.hpp
@@ -11,6 +11,25 @@
 
 namespace inferdeck::model {
 
+// Server-side sampler defaults (issue #42). Values here mirror stock
+// llama-server defaults: DRY off, repeat_penalty neutral. Explicit per-request
+// (OpenAI body) values override these; see make_inference_request /
+// apply_chat_template. Settable globally under `gateway.sampling` and
+// overridable per entry in `model_registry`.
+struct SamplingConfig {
+    float temperature{0.8f};
+    float top_p{0.95f};
+    int   top_k{40};
+    float min_p{0.05f};
+    float repeat_penalty{1.0f};   // 1.0 = disabled
+    int   repeat_last_n{64};
+    float dry_multiplier{0.0f};   // 0.0 = disabled
+    float dry_base{1.75f};
+    int   dry_allowed_length{2};
+    int   dry_penalty_last_n{-1};  // -1 = context size
+    std::vector<std::string> dry_seq_breakers{"\n", ":", "\"", "*"};
+};
+
 struct ModelInfo {
     std::string name{};
     std::string family{};
@@ -22,6 +41,7 @@ struct ModelInfo {
     std::optional<int> n_gpu_layers{};
     bool has_vision{false};
     std::string reasoning_format{};  // "auto", "deepseek", "deepseek_legacy", "none"
+    SamplingConfig sampling{};       // per-model defaults (merged over global at parse time)
 };
 
 struct ChatMessage {
@@ -58,11 +78,14 @@ struct InferenceRequest {
     std::string tools_json{};
     std::string openai_body_json{};
     int max_tokens{512};
-    float temperature{0.7f};
-    float top_p{0.95f};
-    int top_k{40};
-    float repeat_penalty{1.1f};
-    int repeat_last_n{64};
+    // Sampler params are optional so the server can tell an explicit client
+    // value apart from "unset" (issue #42). When unset, the server-side
+    // SamplingConfig default applies; when set, the client value wins.
+    std::optional<float> temperature{};
+    std::optional<float> top_p{};
+    std::optional<int> top_k{};
+    std::optional<float> repeat_penalty{};
+    std::optional<int> repeat_last_n{};
     int seed{-1};
     std::optional<std::string> tool_format{};
     std::optional<std::string> grammar{};


### PR DESCRIPTION
Closes #42.

## What
Replaces the hardcoded sampler (DRY 0.8, repeat_penalty 1.1, min_p 0.05) with a `SamplingConfig` sourced from `gateway.yml`:
- a global `gateway.sampling` block, and
- per-model overrides under `model_registry`.

Defaults mirror stock llama-server (DRY off, repeat_penalty neutral) so reasoning models (Qwen3 / Qwen3.6) stay coherent. Explicit per-request (OpenAI body) values still win; unset request fields fall back to the server-side config.

## Changes
- `imodel`: `SamplingConfig` struct; `InferenceRequest` sampler fields are now `std::optional` (distinguish client-set from unset).
- `routes` / `anthropic_routes`: only carry sampler params the client explicitly set.
- `llama_cpp_model`: resolve per-request over config; remove `build_sampler_locked`; add `request_shape` / `sampling_resolved` debug logs.
- `config`: parse global + per-model sampling; `gateway.yml` documents the blocks.

## Verification
Builds clean off `main` (Release, VS2026), which already includes the #43 scheduler fix.

## Notes
The DRY-off default also removes a long-standing nudge against repeated tool-call scaffolding, complementing #43.