### PR TITLE
fix: per-model chat template override for broken GGUF templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ session-*.md
 *.bak
 /rocblas/
 /hipblaslt/
+/.agents

--- a/apps/inferdeck-gateway/src/config.hpp
+++ b/apps/inferdeck-gateway/src/config.hpp
@@ -172,6 +172,7 @@ inline GatewayConfig load_config(const std::filesystem::path& path) {
             }
             info.has_vision = m["has_vision"] ? m["has_vision"].as<bool>() : false;
             info.reasoning_format = m["reasoning_format"] ? m["reasoning_format"].as<std::string>() : "";
+            info.chat_template_path = m["chat_template_path"] ? m["chat_template_path"].as<std::string>() : "";
             // Per-model sampling overrides inherit the global block, then apply
             // any keys present in this entry (issue #42).
             info.sampling = cfg.sampling;

--- a/apps/inferdeck-gateway/src/main.cpp
+++ b/apps/inferdeck-gateway/src/main.cpp
@@ -278,6 +278,21 @@ int main(int argc, char** argv) {
         lc.truncate_prompt = cfg.truncate_prompt;
         lc.reasoning_format = info.reasoning_format.empty() ? "auto" : info.reasoning_format;
         lc.sampling = info.sampling;  // per-model merged over global (issue #42)
+        // Optional per-model chat-template override (.jinja). Empty path keeps the
+        // template embedded in the GGUF. Used to fix the Qwen3.6 multi-step tool
+        // calling crash ("No user query found in messages.").
+        if (!info.chat_template_path.empty()) {
+            lc.chat_template = read_text_file(info.chat_template_path);
+            if (lc.chat_template.empty()) {
+                LOG_ERROR("chat_template_missing",
+                          "chat_template_path set but file empty/unreadable for {}: {} -- falling back to embedded template",
+                          info.name, info.chat_template_path);
+            } else {
+                LOG_INFO("chat_template_override",
+                         "loaded chat template for {} from {} ({} bytes)",
+                         info.name, info.chat_template_path, lc.chat_template.size());
+            }
+        }
         return std::make_unique<llama_wrapper::LlamaCppModel>(info, lc);
     });
     for (const auto& m : cfg.models) {

--- a/config/gateway.yml
+++ b/config/gateway.yml
@@ -81,6 +81,9 @@ model_registry:
     vram_required_mb: 31000
     context_size: 40960
     has_vision: true
+    # Corrected Qwen3.6 chat template: avoids the "No user query found in messages."
+    # crash during multi-step tool calling (e.g. OpenCode). See config/templates/.
+    chat_template_path: "C:/Inferdeck/config/templates/qwen3.6-fixed.jinja"
     # Per-model sampler overrides inherit the global `gateway.sampling` block
     # above and override only the keys listed here (issue #42).
     # Qwen3 thinking/reasoning sweet spot (Qwen team): temp 0.6, top_p 0.95,
@@ -100,6 +103,9 @@ model_registry:
     vram_required_mb: 24000
     context_size: 100096
     has_vision: false
+    # Corrected Qwen3.6 chat template: avoids the "No user query found in messages."
+    # crash during multi-step tool calling (e.g. OpenCode). See config/templates/.
+    chat_template_path: "C:/Inferdeck/config/templates/qwen3.6-fixed.jinja"
     # Qwen3 thinking/reasoning sweet spot (Qwen team).
     sampling:
       temperature: 0.6
@@ -183,6 +189,10 @@ model_registry:
     vram_required_mb: 13000
     context_size: 32768
     has_vision: false
+    # Corrected gpt-oss harmony template: replaces the "Message has tool role, but there
+    # was no previous assistant message with a tool call!" raise_exception with a graceful
+    # fallback, so multi-step tool calling (OpenCode) no longer 400s. See config/templates/.
+    chat_template_path: "C:/Inferdeck/config/templates/gpt-oss-20b-fixed.jinja"
     # gpt-oss recommended sampling (OpenAI): temp 1.0, top_p 1.0, top_k disabled,
     # min_p 0. Repetition controls off.
     sampling:

--- a/config/templates/gpt-oss-20b-fixed.jinja
+++ b/config/templates/gpt-oss-20b-fixed.jinja
@@ -1,0 +1,400 @@
+{#-
+  In addition to the normal inputs of `messages` and `tools`, this template also accepts the
+  following kwargs:
+  - "builtin_tools": A list, can contain "browser" and/or "python".
+  - "model_identity": A string that optionally describes the model identity.
+  - "reasoning_effort": A string that describes the reasoning effort, defaults to "medium".
+ #}
+
+{#- Tool Definition Rendering ============================================== #}
+{%- macro render_typescript_type(param_spec, required_params, is_nullable=false) -%}
+    {%- if param_spec.type == "array" -%}
+        {%- if param_spec['items'] -%}
+            {%- if param_spec['items']['type'] == "string" -%}
+                {{- "string[]" }}
+            {%- elif param_spec['items']['type'] == "number" -%}
+                {{- "number[]" }}
+            {%- elif param_spec['items']['type'] == "integer" -%}
+                {{- "number[]" }}
+            {%- elif param_spec['items']['type'] == "boolean" -%}
+                {{- "boolean[]" }}
+            {%- else -%}
+                {%- set inner_type = render_typescript_type(param_spec['items'], required_params) -%}
+                {%- if inner_type == "object | object" or inner_type|length > 50 -%}
+                    {{- "any[]" }}
+                {%- else -%}
+                    {{- inner_type + "[]" }}
+                {%- endif -%}
+            {%- endif -%}
+            {%- if param_spec.nullable -%}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- else -%}
+            {{- "any[]" }}
+            {%- if param_spec.nullable -%}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- elif param_spec.type is defined and param_spec.type is iterable and param_spec.type is not string and param_spec.type is not mapping and param_spec.type[0] is defined -%}
+        {#- Handle array of types like ["object", "object"] from Union[dict, list] #}
+        {%- if param_spec.type | length > 1 -%}
+            {{- param_spec.type | join(" | ") }}
+        {%- else -%}
+            {{- param_spec.type[0] }}
+        {%- endif -%}
+    {%- elif param_spec.oneOf -%}
+        {#- Handle oneOf schemas - check for complex unions and fallback to any #}
+        {%- set has_object_variants = false -%}
+        {%- for variant in param_spec.oneOf -%}
+            {%- if variant.type == "object" -%}
+                {%- set has_object_variants = true -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if has_object_variants and param_spec.oneOf|length > 1 -%}
+            {{- "any" }}
+        {%- else -%}
+            {%- for variant in param_spec.oneOf -%}
+                {{- render_typescript_type(variant, required_params) -}}
+                {%- if variant.description %}
+                    {{- "// " + variant.description }}
+                {%- endif -%}
+                {%- if variant.default is defined %}
+                    {{ "// default: " + variant.default|tojson }}
+                {%- endif -%}
+                {%- if not loop.last %}
+                    {{- " | " }}
+                {% endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+    {%- elif param_spec.type == "string" -%}
+        {%- if param_spec.enum -%}
+            {{- '"' + param_spec.enum|join('" | "') + '"' -}}
+        {%- else -%}
+            {{- "string" }}
+            {%- if param_spec.nullable %}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- elif param_spec.type == "number" -%}
+        {{- "number" }}
+    {%- elif param_spec.type == "integer" -%}
+        {{- "number" }}
+    {%- elif param_spec.type == "boolean" -%}
+        {{- "boolean" }}
+
+    {%- elif param_spec.type == "object" -%}
+        {%- if param_spec.properties -%}
+            {{- "{
+" }}
+            {%- for prop_name, prop_spec in param_spec.properties.items() -%}
+                {{- prop_name -}}
+                {%- if prop_name not in (param_spec.required or []) -%}
+                    {{- "?" }}
+                {%- endif -%}
+                {{- ": " }}
+                {{ render_typescript_type(prop_spec, param_spec.required or []) }}
+                {%- if not loop.last -%}
+                    {{-", " }}
+                {%- endif -%}
+            {%- endfor -%}
+            {{- "}" }}
+        {%- else -%}
+            {{- "object" }}
+        {%- endif -%}
+    {%- else -%}
+        {{- "any" }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_tool_namespace(namespace_name, tools) -%}
+    {{- "## " + namespace_name + "
+
+" }}
+    {{- "namespace " + namespace_name + " {
+
+" }}
+    {%- for tool in tools %}
+        {%- set tool = tool.function %}
+        {{- "// " + tool.description + "
+" }}
+        {{- "type "+ tool.name + " = " }}
+        {%- if tool.parameters and tool.parameters.properties %}
+            {{- "(_: {
+" }}
+            {%- for param_name, param_spec in tool.parameters.properties.items() %}
+                {%- if param_spec.description %}
+                    {{- "// " + param_spec.description + "
+" }}
+                {%- endif %}
+                {{- param_name }}
+                {%- if param_name not in (tool.parameters.required or []) -%}
+                    {{- "?" }}
+                {%- endif -%}
+                {{- ": " }}
+                {{- render_typescript_type(param_spec, tool.parameters.required or []) }}
+                {%- if param_spec.default is defined -%}
+                    {%- if param_spec.enum %}
+                        {{- ", // default: " + param_spec.default }}
+                    {%- elif param_spec.oneOf %}
+                        {{- "// default: " + param_spec.default }}
+                    {%- else %}
+                        {{- ", // default: " + param_spec.default|tojson }}
+                    {%- endif -%}
+                {%- endif -%}
+                {%- if not loop.last %}
+                    {{- ",
+" }}
+                {%- else %}
+                    {{- "
+" }}
+                {%- endif -%}
+            {%- endfor %}
+            {{- "}) => any;
+
+" }}
+        {%- else -%}
+            {{- "() => any;
+
+" }}
+        {%- endif -%}
+    {%- endfor %}
+    {{- "} // namespace " + namespace_name }}
+{%- endmacro -%}
+
+{%- macro render_builtin_tools(browser_tool, python_tool) -%}
+    {%- if browser_tool %}
+        {{- "## browser
+
+" }}
+        {{- "// Tool for browsing.
+" }}
+        {{- "// The `cursor` appears in brackets before each browsing display: `[{cursor}]`.
+" }}
+        {{- "// Cite information from the tool using the following format:
+" }}
+        {{- "// `【{cursor}†L{line_start}(-L{line_end})?】`, for example: `【6†L9-L11】` or `【8†L3】`.
+" }}
+        {{- "// Do not quote more than 10 words directly from the tool output.
+" }}
+        {{- "// sources=web (default: web)
+" }}
+        {{- "namespace browser {
+
+" }}
+        {{- "// Searches for information related to `query` and displays `topn` results.
+" }}
+        {{- "type search = (_: {
+" }}
+        {{- "query: string,
+" }}
+        {{- "topn?: number, // default: 10
+" }}
+        {{- "source?: string,
+" }}
+        {{- "}) => any;
+
+" }}
+        {{- "// Opens the link `id` from the page indicated by `cursor` starting at line number `loc`, showing `num_lines` lines.
+" }}
+        {{- "// Valid link ids are displayed with the formatting: `【{id}†.*】`.
+" }}
+        {{- "// If `cursor` is not provided, the most recent page is implied.
+" }}
+        {{- "// If `id` is a string, it is treated as a fully qualified URL associated with `source`.
+" }}
+        {{- "// If `loc` is not provided, the viewport will be positioned at the beginning of the document or centered on the most relevant passage, if available.
+" }}
+        {{- "// Use this function without `id` to scroll to a new location of an opened page.
+" }}
+        {{- "type open = (_: {
+" }}
+        {{- "id?: number | string, // default: -1
+" }}
+        {{- "cursor?: number, // default: -1
+" }}
+        {{- "loc?: number, // default: -1
+" }}
+        {{- "num_lines?: number, // default: -1
+" }}
+        {{- "view_source?: boolean, // default: false
+" }}
+        {{- "source?: string,
+" }}
+        {{- "}) => any;
+
+" }}
+        {{- "// Finds exact matches of `pattern` in the current page, or the page given by `cursor`.
+" }}
+        {{- "type find = (_: {
+" }}
+        {{- "pattern: string,
+" }}
+        {{- "cursor?: number, // default: -1
+" }}
+        {{- "}) => any;
+
+" }}
+        {{- "} // namespace browser
+
+" }}
+    {%- endif -%}
+
+    {%- if python_tool %}
+        {{- "## python
+
+" }}
+        {{- "Use this tool to execute Python code in your chain of thought. The code will not be shown to the user. This tool should be used for internal reasoning, but not for code that is intended to be visible to the user (e.g. when creating plots, tables, or files).
+
+" }}
+        {{- "When you send a message containing Python code to python, it will be executed in a stateful Jupyter notebook environment. python will respond with the output of the execution or time out after 120.0 seconds. The drive at '/mnt/data' can be used to save and persist user files. Internet access for this session is UNKNOWN. Depends on the cluster.
+
+" }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{#- System Message Construction ============================================ #}
+{%- macro build_system_message() -%}
+    {%- if model_identity is not defined %}
+        {%- set model_identity = "You are ChatGPT, a large language model trained by OpenAI." %}
+    {%- endif %}
+    {{- model_identity + "
+" }}
+    {{- "Knowledge cutoff: 2024-06
+" }}
+    {{- "Current date: " + strftime_now("%Y-%m-%d") + "
+
+" }}
+    {%- if reasoning_effort is not defined %}
+        {%- set reasoning_effort = "medium" %}
+    {%- endif %}
+    {{- "Reasoning: " + reasoning_effort + "
+
+" }}
+    {%- if builtin_tools %}
+        {{- "# Tools
+
+" }}
+        {%- set available_builtin_tools = namespace(browser=false, python=false) %}
+        {%- for tool in builtin_tools %}
+            {%- if tool == "browser" %}
+                {%- set available_builtin_tools.browser = true %}
+            {%- elif tool == "python" %}
+                {%- set available_builtin_tools.python = true %}
+            {%- endif %}
+        {%- endfor %}
+        {{- render_builtin_tools(available_builtin_tools.browser, available_builtin_tools.python) }}
+    {%- endif -%}
+    {{- "# Valid channels: analysis, commentary, final. Channel must be included for every message." }}
+    {%- if tools -%}
+        {{- "
+Calls to these tools must go to the commentary channel: 'functions'." }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{#- Main Template Logic ================================================= #}
+{#- Set defaults #}
+
+{#- Render system message #}
+{{- "<|start|>system<|message|>" }}
+{{- build_system_message() }}
+{{- "<|end|>" }}
+
+{#- Extract developer message #}
+{%- if messages[0].role == "developer" or messages[0].role == "system" %}
+    {%- set developer_message = messages[0].content %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set developer_message = "" %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+
+{#- Render developer message #}
+{%- if developer_message or tools %}
+    {{- "<|start|>developer<|message|>" }}
+    {%- if developer_message %}
+        {{- "# Instructions
+
+" }}
+        {{- developer_message }}
+    {%- endif %}
+    {%- if tools -%}
+        {{- "
+
+" }}
+        {{- "# Tools
+
+" }}
+        {{- render_tool_namespace("functions", tools) }}
+    {%- endif -%}
+    {{- "<|end|>" }}
+{%- endif %}
+
+{#- Render messages #}
+{%- set last_tool_call = namespace(name=none) %}
+{%- for message in loop_messages -%}
+    {#- At this point only assistant/user/tool messages should remain #}
+    {%- if message.role == 'assistant' -%}
+        {#- Checks to ensure the messages are being passed in the format we expect #}
+        {%- if "content" in message %}
+            {%- if "<|channel|>analysis<|message|>" in message.content or "<|channel|>final<|message|>" in message.content %}
+                {{- raise_exception("You have passed a message containing <|channel|> tags in the content field. Instead of doing this, you should pass analysis messages (the string between '<|message|>' and '<|end|>') in the 'thinking' field, and final messages (the string between '<|message|>' and '<|end|>') in the 'content' field.") }}
+            {%- endif %}
+        {%- endif %}
+        {%- if "thinking" in message %}
+            {%- if "<|channel|>analysis<|message|>" in message.thinking or "<|channel|>final<|message|>" in message.thinking %}
+                {{- raise_exception("You have passed a message containing <|channel|> tags in the thinking field. Instead of doing this, you should pass analysis messages (the string between '<|message|>' and '<|end|>') in the 'thinking' field, and final messages (the string between '<|message|>' and '<|end|>') in the 'content' field.") }}
+            {%- endif %}
+        {%- endif %}
+        {%- if "tool_calls" in message %}
+            {#- We assume max 1 tool call per message, and so we infer the tool call name #}
+            {#- in "tool" messages from the most recent assistant tool call name #}
+            {%- set tool_call = message.tool_calls[0] %}
+            {%- if tool_call.function %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {%- if message.content and message.thinking %}
+                {{- raise_exception("Cannot pass both content and thinking in an assistant message with tool calls! Put the analysis message in one or the other, but not both.") }}
+            {%- elif message.content %}
+                {{- "<|start|>assistant<|channel|>analysis<|message|>" + message.content + "<|end|>" }}
+            {%- elif message.thinking %}
+                {{- "<|start|>assistant<|channel|>analysis<|message|>" + message.thinking + "<|end|>" }}
+            {%- endif %}
+            {{- "<|start|>assistant to=" }}
+            {{- "functions." + tool_call.name + "<|channel|>commentary " }}
+            {{- (tool_call.content_type if tool_call.content_type is defined else "json") + "<|message|>" }}
+            {{- tool_call.arguments|tojson }}
+            {{- "<|call|>" }}
+            {%- set last_tool_call.name = tool_call.name %}
+        {%- elif loop.last and not add_generation_prompt %}
+            {#- Only render the CoT if the final turn is an assistant turn and add_generation_prompt is false #}
+            {#- This is a situation that should only occur in training, never in inference. #}
+            {%- if "thinking" in message %}
+                {{- "<|start|>assistant<|channel|>analysis<|message|>" + message.thinking + "<|end|>" }}
+            {%- endif %}
+            {#- <|return|> indicates the end of generation, but <|end|> does not #}
+            {#- <|return|> should never be an input to the model, but we include it as the final token #}
+            {#- when training, so the model learns to emit it. #}
+            {{- "<|start|>assistant<|channel|>final<|message|>" + message.content + "<|return|>" }}
+        {%- else %}
+            {#- CoT is dropped during all previous turns, so we never render it for inference #}
+            {{- "<|start|>assistant<|channel|>final<|message|>" + message.content + "<|end|>" }}
+            {%- set last_tool_call.name = none %}
+        {%- endif %}
+    {%- elif message.role == 'tool' -%}
+        {#- Resilient fallback (InferDeck): some agentic clients (e.g. OpenCode) send a
+            tool result without the paired assistant tool-call in history, typically after
+            context compaction. Rather than raise_exception and 400 the whole request,
+            recover the function name from the tool message's own `name` field, else use a
+            generic placeholder. When the pairing IS present, behaviour is unchanged. #}
+        {%- set _tool_fn = last_tool_call.name if last_tool_call.name is not none else (message.name if message.name is defined and message.name else "function") %}
+        {{- "<|start|>functions." + _tool_fn }}
+        {{- " to=assistant<|channel|>commentary<|message|>" + message.content|tojson + "<|end|>" }}
+    {%- elif message.role == 'user' -%}
+        {{- "<|start|>user<|message|>" + message.content + "<|end|>" }}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Generation prompt #}
+{%- if add_generation_prompt -%}
+<|start|>assistant
+{%- endif -%}

--- a/config/templates/qwen3.6-fixed.jinja
+++ b/config/templates/qwen3.6-fixed.jinja
@@ -1,0 +1,287 @@
+{%- set template_version = "qwen3.6-froggeric-v20" %}
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- set add_vision_id = add_vision_id if add_vision_id is defined else false %}
+{%- set enable_thinking = enable_thinking if enable_thinking is defined else true %}
+{%- set auto_disable_thinking_with_tools = auto_disable_thinking_with_tools if auto_disable_thinking_with_tools is defined else false %}
+{%- set _preserve_thinking = preserve_thinking if preserve_thinking is defined else false %}
+{%- set max_tool_arg_chars = max_tool_arg_chars if max_tool_arg_chars is defined else 0 %}
+{%- set max_tool_response_chars = max_tool_response_chars if max_tool_response_chars is defined else 0 %}
+{%- set _has_tools = (tools is defined and tools and tools is iterable and tools is not mapping) %}
+{%- set ns_state = namespace(thinking=enable_thinking) %}
+{%- if auto_disable_thinking_with_tools and _has_tools %}
+    {%- set ns_state.thinking = false %}
+{%- endif %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if item is mapping %}
+                {%- if item.type == 'image' or 'image' in item or 'image_url' in item %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain images.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set image_count.value = image_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+                {%- elif item.type == 'video' or 'video' in item %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain videos.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set video_count.value = video_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Video ' ~ video_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+                {%- elif 'text' in item %}
+                    {{- item.text }}
+                {%- else %}
+                    {{- raise_exception('Unexpected item type in content.') }}
+                {%- endif %}
+            {%- else %}
+                {{- item | string }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set _first_role = messages[0].role %}
+{%- if _first_role == 'system' or _first_role == 'developer' %}
+    {%- set _sys_msg = messages[0] %}
+    {%- set _msgs = messages[1:] %}
+{%- else %}
+    {%- set _sys_msg = none %}
+    {%- set _msgs = messages %}
+{%- endif %}
+{%- set _sc = '' %}
+{%- if _sys_msg is not none %}
+    {%- set _sc = render_content(_sys_msg.content, false, true) | trim %}
+    {%- if '<|think_off|>' in _sc %}
+        {%- set ns_state.thinking = false %}
+        {%- set _sc = _sc.split('<|think_off|>') | join('') | trim %}
+    {%- elif '<|think_on|>' in _sc %}
+        {%- set ns_state.thinking = true %}
+        {%- set _sc = _sc.split('<|think_on|>') | join('') | trim %}
+    {%- endif %}
+{%- endif %}
+{%- if _has_tools %}
+    {{- '<|im_start|>system\n' }}
+    {{- '# Tools\n\nYou have access to the following functions:\n\n<tools>' }}
+    {%- for tool in tools %}
+        {{- '\n' }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- '\n</tools>' }}
+    {%- set tool_instructions %}
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<think>
+Brief explanation of tool call
+</think>
+<tool_call>
+<function=example_function_name>
+<parameter=example_parameter_1>
+value_1
+</parameter>
+<parameter=example_parameter_2>
+This is the value for the second parameter
+that can span
+multiple lines
+</parameter>
+</function>
+</tool_call>
+
+<IMPORTANT>
+Reminder:
+- You can use the <think></think> block to plan your next tool call OR to synthesize data and formulate your final response to the user.
+- ALL explanation and reasoning MUST be placed strictly inside the <think></think> block.
+- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags.
+- If you choose to call a tool, you MUST output the <tool_call> block IMMEDIATELY after closing </think>. Do NOT output any conversational text before the tool call.
+- The <tool_call> and <function> tags MUST be at the very beginning of a new line, with NO spaces or indentation before them.
+- To call multiple functions, output a separate, completely closed <tool_call></tool_call> block for EACH function. Do NOT nest <tool_call> blocks.
+- If you have gathered all necessary data and do not need to call a tool, answer the question like normal and provide your final response to the user IMMEDIATELY after closing </think>.
+</IMPORTANT>
+    {%- endset %}
+    {{- '\n\n' ~ tool_instructions | trim }}
+    {%- if _sc %}
+        {{- '\n\n' + _sc }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if _sc %}
+        {{- '<|im_start|>system\n' + _sc + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set _last_idx = _msgs | length - 1 %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=_last_idx) %}
+{%- for message in _msgs[::-1] %}
+    {%- set index = (_msgs | length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == 'user' %}
+        {%- set _rc = render_content(message.content, false) | trim %}
+        {%- if not (_rc.startswith('<tool_response>') and _rc.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {%- if _last_idx > 50 %}
+        {%- set ns.last_query_index = _last_idx %}
+    {%- else %}
+        {%- set ns.last_query_index = 0 %}
+    {%- endif %}
+{%- endif %}
+{%- set ns2 = namespace(prev_role='', consecutive_failures=0) %}
+{%- for message in _msgs %}
+    {%- set is_system = (message.role == "system" or message.role == "developer") %}
+    {%- set content = render_content(message.content, true, is_system) | trim %}
+    {%- if '<|think_off|>' in content %}
+        {%- set ns_state.thinking = false %}
+        {%- set content = content.split('<|think_off|>') | join('') | trim %}
+    {%- elif '<|think_on|>' in content %}
+        {%- set ns_state.thinking = true %}
+        {%- set content = content.split('<|think_on|>') | join('') | trim %}
+    {%- endif %}
+    {%- if is_system %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- elif message.role == 'user' %}
+        {%- set ns2.consecutive_failures = 0 %}
+        {{- '<|im_start|>user\n' + content + '<|im_end|>\n' }}
+    {%- elif message.role == 'assistant' %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}
+            {%- if message.reasoning_content is string %}
+                {%- set reasoning_content = message.reasoning_content %}
+            {%- else %}
+                {%- set reasoning_content = message.reasoning_content | string %}
+            {%- endif %}
+        {%- else %}
+            {%- set _think_end = '' %}
+            {%- if '</think>' in content %}
+                {%- set _think_end = '</think>' %}
+            {%- elif '</thinking>' in content %}
+                {%- set _think_end = '</thinking>' %}
+            {%- elif '</ think>' in content %}
+                {%- set _think_end = '</ think>' %}
+            {%- elif '</think >' in content %}
+                {%- set _think_end = '</think >' %}
+            {%- endif %}
+            {%- if _think_end %}
+                {%- if _think_end == '</thinking>' %}
+                    {%- set _think_start = '<thinking>' %}
+                {%- else %}
+                    {%- set _think_start = '<think>' %}
+                {%- endif %}
+                {%- set reasoning_content = content.split(_think_end)[0].rstrip('\n') %}
+                {%- if _think_start in reasoning_content %}
+                    {%- set reasoning_content = reasoning_content.split(_think_start)[-1].lstrip('\n') %}
+                {%- endif %}
+                {%- set content = content.split(_think_end)[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content | trim %}
+        {%- if (_preserve_thinking or loop.index0 > ns.last_query_index) and reasoning_content %}
+            {{- '<|im_start|>assistant\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>assistant\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls is defined and message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined and tool_call.function is not none %}
+                    {%- set tc = tool_call.function %}
+                {%- else %}
+                    {%- set tc = tool_call %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content | trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tc.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tc.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n\n<tool_call>\n<function=' + tc.name + '>\n' }}
+                {%- endif %}
+                {%- if tc.arguments is defined and tc.arguments is not none %}
+                    {%- if tc.arguments is mapping %}
+                        {%- for args_name, args_value in tc.arguments.items() %}
+                            {{- '<parameter=' + args_name + '>\n' }}
+                            {%- if args_value is mapping or (args_value is sequence and args_value is not string) %}
+                                {%- set _av = args_value | tojson %}
+                            {%- else %}
+                                {%- set _av = args_value | string %}
+                            {%- endif %}
+                            {%- if max_tool_arg_chars > 0 and _av | length > max_tool_arg_chars %}
+                                {{- _av[:max_tool_arg_chars] + '\n[TRUNCATED — original length ' ~ (_av | length | string) ~ ' chars]' }}
+                            {%- else %}
+                                {{- _av }}
+                            {%- endif %}
+                            {{- '\n</parameter>\n' }}
+                        {%- endfor %}
+                    {%- elif tc.arguments is string and tc.arguments %}
+                        {{- tc.arguments }}
+                    {%- endif %}
+                {%- endif %}
+                {%- if loop.last %}
+                    {{- '</function>\n</tool_call>\n' }}
+                {%- else %}
+                    {{- '</function>\n</tool_call>' }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == 'tool' %}
+        {%- set _content_lower = content | lower %}
+        {%- if content | length < 500 and '$ ' not in content and 'took ' not in _content_lower and ('"error":' in _content_lower or 'error:' in _content_lower or 'exception:' in _content_lower or 'traceback' in _content_lower or 'command not found' in _content_lower or 'invalid syntax' in _content_lower or 'failed to' in _content_lower) %}
+            {%- set ns2.consecutive_failures = ns2.consecutive_failures + 1 %}
+        {%- else %}
+            {%- set ns2.consecutive_failures = 0 %}
+        {%- endif %}
+        {%- if ns2.prev_role != 'tool' %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {%- if max_tool_response_chars > 0 and content | length > max_tool_response_chars %}
+            {%- set content = content[:max_tool_response_chars] + '\n[TRUNCATED — original length ' ~ (content | length | string) ~ ' chars]' %}
+        {%- endif %}
+        {{- '\n<tool_response>\n' + content }}
+        {%- if ns2.consecutive_failures >= 2 %}
+            {{- '\n\n⚠️ SYSTEM WARNING: ' ~ ns2.consecutive_failures ~ ' consecutive tool errors detected. Your previous approach is incorrect. You MUST use a fundamentally different approach or corrected arguments.' }}
+        {%- elif ns2.consecutive_failures == 1 %}
+            {{- '\n\n⚠️ SYSTEM WARNING: The previous tool call returned an error. Diagnose the failure and retry with completely corrected arguments.' }}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- else %}
+            {%- set _next_role = _msgs[loop.index0 + 1].role %}
+            {%- if _next_role != 'tool' %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>user\n[' + message.role + ']: ' + content + '<|im_end|>\n' }}
+    {%- endif %}
+    {%- set ns2.prev_role = message.role %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if not ns_state.thinking %}
+        {{- '<think>\n</think>\n' }}
+    {%- elif ns2.consecutive_failures >= 2 %}
+        {{- '<think>\n</think>\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -877,7 +877,10 @@ Result<void> LlamaCppModel::load() {
     return Result<void>(std::unexpect,
         make_error(ErrorCode::ParseError, "llama_model_get_vocab returned null"));
   }
-  chat_templates_ = common_chat_templates_init(model_, "").release();
+  // Empty cfg_.chat_template => use the template embedded in the GGUF; a non-empty
+  // value is a literal Jinja override (e.g. the corrected Qwen3.6 template that avoids
+  // the "No user query found in messages." crash during multi-step tool calling).
+  chat_templates_ = common_chat_templates_init(model_, cfg_.chat_template).release();
   if (chat_templates_ == nullptr) {
     llama_model_free(model_);
     model_ = nullptr;

--- a/libs/model/include/model/imodel.hpp
+++ b/libs/model/include/model/imodel.hpp
@@ -41,6 +41,7 @@ struct ModelInfo {
     std::optional<int> n_gpu_layers{};
     bool has_vision{false};
     std::string reasoning_format{};  // "auto", "deepseek", "deepseek_legacy", "none"
+    std::string chat_template_path{};  // optional .jinja override; empty = use template embedded in GGUF
     SamplingConfig sampling{};       // per-model defaults (merged over global at parse time)
 };
 


### PR DESCRIPTION
Closes #49

## Problem
Multi-step tool calling (OpenCode) 400s on two model families due to bugs in GGUF-embedded chat templates:
- Qwen3.6: `No user query found in messages.`
- gpt-oss-20b: `Message has tool role, but there was no previous assistant message with a tool call!` (template raise_exception instead of graceful fallback)

## Fix
- New optional `chat_template_path` per `model_registry` entry in `gateway.yml`; empty = GGUF-embedded template, unchanged behavior
- Gateway loads the `.jinja` at startup, passes it through `ModelInfo` to `common_chat_templates_init`
- Corrected templates for both families in `config/templates/` (Qwen3.6: tolerate tool-continuation turns; gpt-oss: graceful fallback instead of raise_exception)
- `.gitignore`: ignore `.agents/`

## Testing
Deployed to live box 2026-07-04 and verified: OpenCode multi-step tool-calling sessions against both qwen3.6 models and gpt-oss-20b no longer crash; previously-failing conversations complete.