### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,30 @@
 # InferDeck - Changelog
 
+## [0.4.0] - 2026-07-04
+
+### Added
+- **Dashboard visual hierarchy and metric context.** Hero-sized primary stat on
+  Overview, context sub-lines on stats/sparklines (VRAM budget, token share),
+  text status badges (OK/Warm/Hot) so state never relies on color alone, and
+  explicit time windows on every section title.
+  Closes [#46](https://github.com/davidtaylor6130/InferDeck/issues/46)
+- **Usage chart hover tooltip** showing per-bucket time, token breakdown, and
+  cost, with guide line and point highlights.
+- **Per-model `chat_template_path` override** in `gateway.yml` for models whose
+  GGUF-embedded chat template is broken; corrected Qwen3.6 and gpt-oss-20b
+  templates shipped in `config/templates/`.
+  Closes [#49](https://github.com/davidtaylor6130/InferDeck/issues/49)
+
+### Fixed
+- **Usage chart tick labels aligned to plotted points** and the line now spans
+  the full chart width (was inset and misaligned).
+  Closes [#47](https://github.com/davidtaylor6130/InferDeck/issues/47)
+- **Multi-step tool calling no longer 400s** on Qwen3.6 ("No user query found
+  in messages.") and gpt-oss-20b ("Message has tool role...") via the template
+  overrides above.
+
+---
+
 ## [0.3.0] - 2026-06-25
 
 ### Added

--- a/apps/benchmark-runner/src/main.cpp
+++ b/apps/benchmark-runner/src/main.cpp
@@ -107,9 +107,9 @@ int main(int argc, char** argv) {
   using namespace inferdeck::optimize;
   const Args args = parse_args(argc, argv);
   if (args.show_help) { print_help(); return 0; }
-  if (args.show_version) { std::cout << "inferdeck-bench 0.3.0\n"; return 0; }
+  if (args.show_version) { std::cout << "inferdeck-bench 0.4.0\n"; return 0; }
 
-  std::cout << "inferdeck-bench 0.3.0\n"
+  std::cout << "inferdeck-bench 0.4.0\n"
             << "  model=" << args.model
             << " suite=" << args.suite
             << " trials=" << args.trials

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/inferdeck-gateway/src/main.cpp
+++ b/apps/inferdeck-gateway/src/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
             std::cout << "Usage: " << argv[0] << " [-c config.yml]\n";
             return 0;
         } else if (a == "-v" || a == "--version") {
-            std::cout << "inferdeck-gateway 0.3.0\n";
+            std::cout << "inferdeck-gateway 0.4.0\n";
             return 0;
         }
     }
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
     AddVectoredExceptionHandler(0, CrashHandler);
 #endif
 
-    LOG_INFO("startup", "inferdeck-gateway 0.3.0 starting");
+    LOG_INFO("startup", "inferdeck-gateway 0.4.0 starting");
     LOG_INFO("config", "loaded from {}", config_path.string());
     LOG_INFO("vulkan_test", "About to initialize llama backend");
     std::cerr << "DEBUG: About to call llama_backend_init()" << std::endl;


### PR DESCRIPTION
Version bump to 0.4.0 + CHANGELOG entry covering #46, #47 (dashboard, PR #48) and #49 (chat template overrides, PR #50).

After merge: tag `v0.4.0` on the merge commit to trigger the release workflow.