### PR TITLE
Fix release scheduler race

### DIFF
--- a/libs/gateway/include/gateway/profile_benchmark_scheduler.hpp
+++ b/libs/gateway/include/gateway/profile_benchmark_scheduler.hpp
@@ -45,6 +45,7 @@ private:
     ProfileBenchmarkManager& manager_;
     model::BackendCoordinator& coordinator_;
     observability::GpuTelemetry& gpu_;
+    std::mutex evaluate_mutex_;
     mutable std::mutex mutex_;
     std::unordered_map<std::string, ScheduledOptimizationStatus> state_;
     std::unordered_map<std::string, std::string> attempted_date_;

--- a/libs/gateway/src/profile_benchmark_scheduler.cpp
+++ b/libs/gateway/src/profile_benchmark_scheduler.cpp
@@ -107,6 +107,8 @@ std::vector<ScheduledOptimizationStatus> ProfileBenchmarkScheduler::statuses() c
 }
 
 void ProfileBenchmarkScheduler::evaluate() {
+    std::lock_guard evaluate_lock(evaluate_mutex_);
+
     {
         std::lock_guard lock(mutex_);
         if (!in_flight_model_.empty()) {


### PR DESCRIPTION
## What changed

Serialize scheduled benchmark evaluations so the background loop and an explicit evaluation cannot race during startup.

## Root cause

The release runner exposed a gap where one evaluation reserved the benchmark resource before recording the manager as running. A concurrent evaluation could then return, while the test observed the initial never-started state and completed too early.

## Validation

- Exact failing scheduler test: 100/100 passes
- Local Release unit/integration suite: 116/116 passes
- Local full CMake Release build: passes
- GitHub Release dry-run: [31979779772](https://github.com/davidtaylor6130/InferDeck/actions/runs/31979779772) passed build, tests, packaging, and artifact upload