### PR TITLE
Fix GPU utilization and reasoning effort for 0.7.2

### DIFF
--- a/apps/inferdeck-gateway/src/config.hpp
+++ b/apps/inferdeck-gateway/src/config.hpp
@@ -331,6 +331,67 @@ inline foundation::Result<void> validate_config_node(const YAML::Node& root) {
                         foundation::ErrorCode::InvalidArgument,
                         "vision model requires llama_cpp and mmproj_path: " + name);
                 }
+                if (entry["reasoning"]) {
+                    const auto reasoning = entry["reasoning"];
+                    if (!reasoning.IsMap()) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "model reasoning settings must be a map: " + name);
+                    }
+                    const bool supported = reasoning["supported"]
+                        ? reasoning["supported"].as<bool>() : true;
+                    if (!supported && reasoning.size() > 1) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "unsupported reasoning model cannot define effort settings: " + name);
+                    }
+                    if (supported && (runtime != "llama_cpp" || modality != "text")) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "reasoning requires a llama_cpp text model: " + name);
+                    }
+                    std::unordered_set<std::string> efforts;
+                    if (supported &&
+                        (!reasoning["efforts"] || !reasoning["efforts"].IsSequence() ||
+                         reasoning["efforts"].size() == 0)) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "reasoning efforts must be a non-empty sequence: " + name);
+                    }
+                    if (reasoning["efforts"]) {
+                        for (const auto& effort : reasoning["efforts"]) {
+                            const auto value = effort.as<std::string>();
+                            if (value.empty() || value == "none" || !efforts.insert(value).second) {
+                                return foundation::Err<void>(
+                                    foundation::ErrorCode::InvalidArgument,
+                                    "reasoning efforts must be unique non-empty tiers: " + name);
+                            }
+                        }
+                    }
+                    const auto default_effort = reasoning["default"]
+                        ? reasoning["default"].as<std::string>() : std::string{};
+                    if (supported && !efforts.contains(default_effort)) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "reasoning default must be a supported effort: " + name);
+                    }
+                    if (reasoning["aliases"] && !reasoning["aliases"].IsMap()) {
+                        return foundation::Err<void>(
+                            foundation::ErrorCode::InvalidArgument,
+                            "reasoning aliases must be a map: " + name);
+                    }
+                    if (reasoning["aliases"]) {
+                        for (const auto& alias : reasoning["aliases"]) {
+                            const auto source = alias.first.as<std::string>();
+                            const auto target = alias.second.as<std::string>();
+                            if (source.empty() || source == "none" || !efforts.contains(target)) {
+                                return foundation::Err<void>(
+                                    foundation::ErrorCode::InvalidArgument,
+                                    "reasoning alias must map to a supported effort: " + name);
+                            }
+                        }
+                    }
+                }
                 if (entry["speculative"]) {
                     const auto speculative = entry["speculative"];
                     if (!speculative.IsMap()) {
@@ -628,6 +689,26 @@ inline GatewayConfig load_config(const std::filesystem::path& path) {
             info.has_vision = m["has_vision"] ? m["has_vision"].as<bool>() : false;
             info.reasoning_format = m["reasoning_format"] ? m["reasoning_format"].as<std::string>() : "";
             info.chat_template_path = m["chat_template_path"] ? m["chat_template_path"].as<std::string>() : "";
+            if (m["reasoning"] && m["reasoning"].IsMap()) {
+                const auto reasoning = m["reasoning"];
+                info.reasoning.supported = reasoning["supported"]
+                    ? reasoning["supported"].as<bool>() : true;
+                if (reasoning["efforts"] && reasoning["efforts"].IsSequence()) {
+                    for (const auto& effort : reasoning["efforts"]) {
+                        info.reasoning.efforts.push_back(effort.as<std::string>());
+                    }
+                }
+                info.reasoning.default_effort = reasoning["default"]
+                    ? reasoning["default"].as<std::string>() : "";
+                info.reasoning.none_disables = reasoning["none_disables"]
+                    ? reasoning["none_disables"].as<bool>() : false;
+                if (reasoning["aliases"] && reasoning["aliases"].IsMap()) {
+                    for (const auto& alias : reasoning["aliases"]) {
+                        info.reasoning.aliases[alias.first.as<std::string>()] =
+                            alias.second.as<std::string>();
+                    }
+                }
+            }
             if (m["prompt_price_per_million"]) {
                 info.prompt_price_per_million = m["prompt_price_per_million"].as<double>();
             }

--- a/apps/inferdeck-gateway/tests/test_config.cpp
+++ b/apps/inferdeck-gateway/tests/test_config.cpp
@@ -114,6 +114,12 @@ TEST_CASE("Repository Qwen 3.8 27B profile enables adaptive MTP",
     CHECK(*qwen->n_ubatch == 2048);
     CHECK(qwen->cache_type_k == "q4_0");
     CHECK(qwen->cache_type_v == "q4_0");
+    CHECK(qwen->reasoning.supported);
+    CHECK(qwen->reasoning.efforts ==
+          std::vector<std::string>{"low", "medium", "xhigh"});
+    CHECK(qwen->reasoning.default_effort == "xhigh");
+    CHECK(qwen->reasoning.none_disables);
+    CHECK(qwen->reasoning.aliases.at("high") == "xhigh");
     CHECK(qwen->mtp_enabled);
     CHECK(qwen->mtp_draft_tokens == 2);
     CHECK(qwen->mtp_p_min == 0.0f);
@@ -264,6 +270,24 @@ model_registry:
     gguf_path: model.gguf
     sampling:
       top_p: 1.5
+)"));
+    CHECK_FALSE(validate_config_text(R"(
+model_registry:
+  - name: bad-reasoning-default
+    gguf_path: model.gguf
+    reasoning:
+      efforts: [low, high]
+      default: medium
+)"));
+    CHECK_FALSE(validate_config_text(R"(
+model_registry:
+  - name: bad-reasoning-alias
+    gguf_path: model.gguf
+    reasoning:
+      efforts: [low, high]
+      default: high
+      aliases:
+        xhigh: unsupported
 )"));
     CHECK_FALSE(validate_config_text(R"(
 model_registry:

--- a/config/gateway.yml
+++ b/config/gateway.yml
@@ -149,6 +149,13 @@ model_registry:
     n_ubatch: 2048
     cache_type_k: "q4_0"
     cache_type_v: "q4_0"
+    reasoning:
+      supported: true
+      efforts: [low, medium, xhigh]
+      default: xhigh
+      none_disables: true
+      aliases:
+        high: xhigh
     speculative:
       type: "mtp"
       draft_tokens: 2

--- a/docs/opencode-setup-guide.md
+++ b/docs/opencode-setup-guide.md
@@ -50,6 +50,43 @@ opencode run "Read arch-findings.md.
 Create optimization-plan.md with actionable recommendations."
 ```
 
+## Reasoning Effort
+
+InferDeck accepts `reasoning_effort` on Chat Completions and
+`reasoning.effort` on Responses. Supported values are advertised per model by
+`GET /v1/models`; unsupported values return HTTP 400.
+
+The bundled `qwen3.8-27b` profile supports `low`, `medium`, `xhigh`, and `none`.
+Its embedded template treats `high` as an alias for `xhigh`, uses `xhigh` by
+default, and uses `none` to disable reasoning.
+
+Add the model to the InferDeck provider in `opencode.json` with explicit
+variants so OpenCode exposes them through `/variants` and `variant_cycle`:
+
+```json
+{
+  "qwen3.8-27b": {
+    "name": "qwen3.8-27b",
+    "reasoning": true,
+    "limit": { "context": 100000, "output": 16384 },
+    "modalities": {
+      "input": ["text", "image"],
+      "output": ["text"]
+    },
+    "variants": {
+      "low": { "reasoningEffort": "low" },
+      "medium": { "reasoningEffort": "medium" },
+      "xhigh": { "reasoningEffort": "xhigh" },
+      "off": { "reasoningEffort": "none" }
+    }
+  }
+}
+```
+
+`chat_template_kwargs.reasoning_effort` remains supported and takes precedence
+over the protocol-level field. If neither is supplied, the model profile's
+default is used.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/libs/gateway/src/openai_routes.cpp
+++ b/libs/gateway/src/openai_routes.cpp
@@ -208,7 +208,7 @@ foundation::Result<nlohmann::json> responses_to_chat(const nlohmann::json& body)
     static const std::unordered_set<std::string> supported = {
         "model", "input", "instructions", "max_output_tokens", "temperature", "top_p",
         "tools", "tool_choice", "text", "stream", "priority", "metadata",
-        "parallel_tool_calls",
+        "parallel_tool_calls", "reasoning",
     };
     if (!body.is_object()) {
         return foundation::Err<nlohmann::json>(foundation::ErrorCode::InvalidArgument,
@@ -289,6 +289,28 @@ foundation::Result<nlohmann::json> responses_to_chat(const nlohmann::json& body)
         return foundation::Err<nlohmann::json>(
             foundation::ErrorCode::InvalidArgument,
             "parallel_tool_calls must be a boolean");
+    }
+    if (body.contains("reasoning")) {
+        if (!body["reasoning"].is_object()) {
+            return foundation::Err<nlohmann::json>(
+                foundation::ErrorCode::InvalidArgument,
+                "reasoning must be an object");
+        }
+        static const std::unordered_set<std::string> reasoning_fields = {
+            "effort",
+        };
+        auto fields = require_fields(body["reasoning"], reasoning_fields,
+                                     "reasoning");
+        if (!fields) {
+            return foundation::Err<nlohmann::json>(
+                fields.error().code, fields.error().message);
+        }
+        if (!body["reasoning"].contains("effort") ||
+            !body["reasoning"]["effort"].is_string()) {
+            return foundation::Err<nlohmann::json>(
+                foundation::ErrorCode::InvalidArgument,
+                "reasoning.effort must be a string");
+        }
     }
     if (body.contains("metadata") && !body["metadata"].is_object()) {
         return foundation::Err<nlohmann::json>(
@@ -459,6 +481,7 @@ foundation::Result<nlohmann::json> responses_to_chat(const nlohmann::json& body)
     if (body.contains("top_p")) chat["top_p"] = body["top_p"];
     if (body.contains("priority")) chat["priority"] = body["priority"];
     if (body.contains("parallel_tool_calls")) chat["parallel_tool_calls"] = body["parallel_tool_calls"];
+    if (body.contains("reasoning")) chat["reasoning_effort"] = body["reasoning"]["effort"];
     chat["stream"] = body.value("stream", false);
     if (chat["stream"].get<bool>()) chat["stream_options"] = {{"include_usage", true}};
 

--- a/libs/gateway/src/routes.cpp
+++ b/libs/gateway/src/routes.cpp
@@ -340,6 +340,80 @@ foundation::Result<model::InferenceRequest> make_inference_request(
     }
 }
 
+foundation::Result<std::optional<std::string>> normalize_reasoning_request(
+    nlohmann::json& body, const model::ModelInfo& info) {
+    std::optional<std::string> requested;
+    bool supplied = false;
+    bool explicit_kwarg = false;
+    if (body.contains("reasoning_effort")) {
+        supplied = true;
+        if (!body["reasoning_effort"].is_string()) {
+            return foundation::Err<std::optional<std::string>>(
+                foundation::ErrorCode::InvalidArgument,
+                "reasoning_effort must be a string");
+        }
+        requested = body["reasoning_effort"].get<std::string>();
+    }
+    if (body.contains("chat_template_kwargs")) {
+        if (!body["chat_template_kwargs"].is_object()) {
+            return foundation::Err<std::optional<std::string>>(
+                foundation::ErrorCode::InvalidArgument,
+                "chat_template_kwargs must be an object");
+        }
+        auto& kwargs = body["chat_template_kwargs"];
+        if (kwargs.contains("reasoning_effort")) {
+            supplied = true;
+            explicit_kwarg = true;
+            if (!kwargs["reasoning_effort"].is_string()) {
+                return foundation::Err<std::optional<std::string>>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "chat_template_kwargs.reasoning_effort must be a string");
+            }
+            requested = kwargs["reasoning_effort"].get<std::string>();
+        }
+    }
+    if (!requested && info.reasoning.supported &&
+        !info.reasoning.default_effort.empty()) {
+        requested = info.reasoning.default_effort;
+    }
+    if (!requested) return foundation::Ok(std::optional<std::string>{});
+    if (!info.reasoning.supported) {
+        return foundation::Err<std::optional<std::string>>(
+            foundation::ErrorCode::InvalidArgument,
+            "model does not support reasoning effort: " + info.name);
+    }
+
+    std::string resolved = *requested;
+    if (const auto alias = info.reasoning.aliases.find(resolved);
+        alias != info.reasoning.aliases.end()) {
+        resolved = alias->second;
+    }
+    if (resolved == "none") {
+        if (!info.reasoning.none_disables) {
+            return foundation::Err<std::optional<std::string>>(
+                foundation::ErrorCode::InvalidArgument,
+                "reasoning effort 'none' is not supported by model: " + info.name);
+        }
+    } else if (std::find(info.reasoning.efforts.begin(),
+                         info.reasoning.efforts.end(), resolved) ==
+               info.reasoning.efforts.end()) {
+        return foundation::Err<std::optional<std::string>>(
+            foundation::ErrorCode::InvalidArgument,
+            "unsupported reasoning effort '" + *requested + "' for model: " +
+                info.name);
+    }
+
+    body["reasoning_effort"] = resolved;
+    if (explicit_kwarg) {
+        body["chat_template_kwargs"]["reasoning_effort"] = resolved;
+    }
+    LOG_INFO("reasoning_effort_resolved", "model={} effort={} source={}",
+             info.name, resolved,
+             explicit_kwarg ? "chat_template_kwargs"
+                            : (supplied ? "protocol" : "model_default"));
+    return foundation::Ok(std::optional<std::string>{std::move(resolved)});
+}
+
 struct ErrorClass {
     int status;
     std::string type;
@@ -472,6 +546,13 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
             {"estimated_vram_mb", 0},
             {"resizing", false},
         };
+        const nlohmann::json reasoning = {
+            {"supported", info.reasoning.supported},
+            {"efforts", info.reasoning.efforts},
+            {"default_effort", info.reasoning.default_effort},
+            {"none_disables", info.reasoning.none_disables},
+            {"aliases", info.reasoning.aliases},
+        };
         nlohmann::json entry = {
             {"id", name},
             {"object", "model"},
@@ -486,6 +567,9 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
             {"limit", {{"context", info.context_size}}},
             {"n_slots", info.n_slots},
             {"has_vision", info.has_vision},
+            {"reasoning", info.reasoning.supported},
+            {"reasoning_efforts", info.reasoning.efforts},
+            {"reasoning_default_effort", info.reasoning.default_effort},
             {"runtime", info.runtime},
             {"runtime_available", runtime_available},
             {"modality", info.modality},
@@ -511,6 +595,7 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
                 {"runtime_available", runtime_available},
                 {"modality", info.modality},
                 {"capabilities", info.capabilities},
+                {"reasoning", reasoning},
                 {"optimization", {
                     {"status", info.optimization.status},
                     {"measured_at", info.optimization.measured_at},
@@ -535,6 +620,13 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
         const auto info = deps.coordinator.registry().get_info_result(alias.target);
         if (!info) continue;
         const auto resident = residency.find(alias.target);
+        const nlohmann::json reasoning = {
+            {"supported", info->reasoning.supported},
+            {"efforts", info->reasoning.efforts},
+            {"default_effort", info->reasoning.default_effort},
+            {"none_disables", info->reasoning.none_disables},
+            {"aliases", info->reasoning.aliases},
+        };
         data.push_back({
             {"id", alias.name},
             {"object", "model"},
@@ -551,6 +643,9 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
             {"limit", {{"context", info->context_size}}},
             {"n_slots", info->n_slots},
             {"has_vision", info->has_vision},
+            {"reasoning", info->reasoning.supported},
+            {"reasoning_efforts", info->reasoning.efforts},
+            {"reasoning_default_effort", info->reasoning.default_effort},
             {"runtime", info->runtime},
             {"runtime_available", deps.coordinator.registry().has_factory(info->runtime)},
             {"modality", info->modality},
@@ -565,6 +660,7 @@ void handle_models(const httplib::Request& req, httplib::Response& resp,
                 {"runtime_available", deps.coordinator.registry().has_factory(info->runtime)},
                 {"modality", info->modality},
                 {"capabilities", info->capabilities},
+                {"reasoning", reasoning},
                 {"alias_contract", {
                     {"target", alias.target},
                     {"required_context_size", alias.required_context_size},
@@ -989,9 +1085,19 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
         return;
     }
     const auto model_info = deps.coordinator.registry().get_info_result(model_name);
-    if (model_info && !model_info->has_vision && chat_uses_vision(body)) {
+    if (!model_info) {
+        write_error(resp, 404, "model_not_found", model_info.error().message);
+        return;
+    }
+    if (!model_info->has_vision && chat_uses_vision(body)) {
         write_error(resp, 400, "unsupported_capability",
                     "model does not support image input: " + model_name);
+        return;
+    }
+    auto reasoning_effort = normalize_reasoning_request(body, *model_info);
+    if (!reasoning_effort) {
+        write_error(resp, 400, "invalid_request_error",
+                    reasoning_effort.error().message);
         return;
     }
     if (body.contains("stream") && !body["stream"].is_boolean()) {

--- a/libs/gateway/tests/test_routes.cpp
+++ b/libs/gateway/tests/test_routes.cpp
@@ -154,8 +154,12 @@ public:
     }
 
     Result<InferenceResult> predict_stream(
-        int, const InferenceRequest&, const TokenCallback& callback,
+        int, const InferenceRequest& request, const TokenCallback& callback,
         const std::atomic<bool>* cancel = nullptr) override {
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            last_request_json = request.openai_body_json;
+        }
         if (context_error.load()) {
             return inferdeck::foundation::Err<InferenceResult>(
                 ErrorCode::ContextLengthExceeded, "prompt is too long");
@@ -501,7 +505,12 @@ bool wait_for_count(const std::atomic<int>& count, int minimum) {
 
 TEST_CASE("Routes: GET /v1/models lists registered models", "[routes][models]") {
     TestServer ts;
-    ts.registry.register_model(make_info("qwen3.6-27b"));
+    auto reasoning_model = make_info("qwen3.6-27b");
+    reasoning_model.reasoning.supported = true;
+    reasoning_model.reasoning.efforts = {"low", "medium", "high"};
+    reasoning_model.reasoning.default_effort = "medium";
+    reasoning_model.reasoning.none_disables = true;
+    ts.registry.register_model(reasoning_model);
     ts.registry.register_model(make_info("qwen3-coder-next"));
     REQUIRE(ts.start());
 
@@ -523,6 +532,16 @@ TEST_CASE("Routes: GET /v1/models lists registered models", "[routes][models]") 
     REQUIRE(body["data"][0]["modality"] == "text");
     REQUIRE(body["data"][0]["inferdeck"]["capabilities"].is_array());
     REQUIRE(body["data"][0]["inferdeck"]["resources"]["configured_slots"] == 2);
+    const auto reasoning_entry = std::find_if(
+        body["data"].begin(), body["data"].end(), [](const auto& entry) {
+            return entry.value("id", "") == "qwen3.6-27b";
+        });
+    REQUIRE(reasoning_entry != body["data"].end());
+    REQUIRE((*reasoning_entry)["reasoning"] == true);
+    REQUIRE((*reasoning_entry)["reasoning_efforts"] ==
+            nlohmann::json::array({"low", "medium", "high"}));
+    REQUIRE((*reasoning_entry)["reasoning_default_effort"] == "medium");
+    REQUIRE((*reasoning_entry)["inferdeck"]["reasoning"]["none_disables"] == true);
     ts.stop();
 }
 
@@ -887,6 +906,107 @@ TEST_CASE("Routes: POST /v1/responses translates string input and output", "[rou
     REQUIRE(body["output"][0]["content"][0]["text"] == "Hello from model");
     REQUIRE(body["usage"]["input_tokens"] == 3);
     REQUIRE(body["usage"]["output_tokens"] == 4);
+    ts.stop();
+}
+
+TEST_CASE("Routes: reasoning effort precedence and defaults reach inference",
+          "[routes][chat][reasoning]") {
+    TestServer ts;
+    auto info = make_info("reasoning-model");
+    info.reasoning.supported = true;
+    info.reasoning.efforts = {"low", "medium", "xhigh"};
+    info.reasoning.default_effort = "xhigh";
+    info.reasoning.none_disables = true;
+    info.reasoning.aliases = {{"high", "xhigh"}};
+    ts.registry.register_model(info);
+    REQUIRE(ts.coordinator.load(info.name));
+    REQUIRE(ts.start());
+
+    httplib::Client client("127.0.0.1", ts.port);
+    auto response = client.Post("/v1/chat/completions", nlohmann::json{
+        {"model", info.name},
+        {"messages", nlohmann::json::array({{{"role", "user"}, {"content", "Hello"}}})},
+        {"reasoning_effort", "medium"},
+        {"chat_template_kwargs", {{"reasoning_effort", "low"}}},
+    }.dump(), "application/json");
+    REQUIRE(response);
+    REQUIRE(response->status == 200);
+    auto* model = dynamic_cast<const IModelMock*>(ts.coordinator.get_model(info.name));
+    REQUIRE(model != nullptr);
+    auto request = nlohmann::json::parse(model->last_request_json);
+    CHECK(request["reasoning_effort"] == "low");
+    CHECK(request["chat_template_kwargs"]["reasoning_effort"] == "low");
+
+    response = client.Post("/v1/chat/completions", nlohmann::json{
+        {"model", info.name},
+        {"messages", nlohmann::json::array({{{"role", "user"}, {"content", "Hello"}}})},
+    }.dump(), "application/json");
+    REQUIRE(response);
+    REQUIRE(response->status == 200);
+    request = nlohmann::json::parse(model->last_request_json);
+    CHECK(request["reasoning_effort"] == "xhigh");
+    ts.stop();
+}
+
+TEST_CASE("Routes: reasoning effort validation occurs before acquisition",
+          "[routes][chat][reasoning][validation]") {
+    TestServer ts;
+    auto info = make_info("reasoning-model");
+    info.reasoning.supported = true;
+    info.reasoning.efforts = {"low", "medium", "xhigh"};
+    info.reasoning.default_effort = "xhigh";
+    ts.registry.register_model(info);
+    ts.registry.register_model(make_info("plain-model"));
+
+    for (const auto& body : std::vector<nlohmann::json>{
+             {{"model", info.name}, {"messages", nlohmann::json::array()},
+              {"reasoning_effort", "maximum"}},
+             {{"model", info.name}, {"messages", nlohmann::json::array()},
+              {"reasoning_effort", "none"}},
+             {{"model", "plain-model"}, {"messages", nlohmann::json::array()},
+              {"reasoning_effort", "medium"}},
+         }) {
+        httplib::Request request;
+        request.body = body.dump();
+        httplib::Response response;
+        handle_chat_completions(request, response, ts.make_deps());
+        CHECK(response.status == 400);
+    }
+    CHECK(ts.metrics.total_requests() == 0);
+}
+
+TEST_CASE("Routes: Responses reasoning effort translates for streaming and non-streaming",
+          "[routes][responses][reasoning]") {
+    TestServer ts;
+    auto info = make_info("reasoning-model");
+    info.reasoning.supported = true;
+    info.reasoning.efforts = {"low", "medium", "xhigh"};
+    info.reasoning.default_effort = "xhigh";
+    info.reasoning.none_disables = true;
+    ts.registry.register_model(info);
+    REQUIRE(ts.coordinator.load(info.name));
+    REQUIRE(ts.start());
+
+    httplib::Client client("127.0.0.1", ts.port);
+    auto response = client.Post("/v1/responses", nlohmann::json{
+        {"model", info.name}, {"input", "Hello"},
+        {"reasoning", {{"effort", "medium"}}},
+    }.dump(), "application/json");
+    REQUIRE(response);
+    REQUIRE(response->status == 200);
+    auto* model = dynamic_cast<const IModelMock*>(ts.coordinator.get_model(info.name));
+    REQUIRE(model != nullptr);
+    CHECK(nlohmann::json::parse(model->last_request_json)["reasoning_effort"] ==
+          "medium");
+
+    response = client.Post("/v1/responses", nlohmann::json{
+        {"model", info.name}, {"input", "Hello"}, {"stream", true},
+        {"reasoning", {{"effort", "none"}}},
+    }.dump(), "application/json");
+    REQUIRE(response);
+    REQUIRE(response->status == 200);
+    CHECK(nlohmann::json::parse(model->last_request_json)["reasoning_effort"] ==
+          "none");
     ts.stop();
 }
 

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "chat.h"
 #include "common.h"
 #include "model/imodel.hpp"
@@ -58,6 +60,11 @@ struct LlamaCppConfig {
   std::string reasoning_format{};  // "auto", "deepseek", "deepseek_legacy", "none"
   inferdeck::model::SamplingConfig sampling{};  // server-side sampler defaults (issue #42)
 };
+
+inferdeck::foundation::Result<std::string> apply_reasoning_effort(
+    common_chat_templates_inputs& inputs,
+    const nlohmann::ordered_json& body,
+    const inferdeck::model::ModelInfo& info);
 
 class LlamaCppModel final : public inferdeck::model::IModel,
                             public inferdeck::model::IEmbeddingBackend {

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -763,6 +763,66 @@ bool fallback_tool_call_complete(const std::string& generated) {
 
 } // namespace
 
+foundation::Result<std::string> apply_reasoning_effort(
+    common_chat_templates_inputs& inputs,
+    const nlohmann::ordered_json& body,
+    const model::ModelInfo& info) {
+  std::optional<std::string> requested;
+  if (body.contains("chat_template_kwargs") &&
+      body["chat_template_kwargs"].is_object() &&
+      body["chat_template_kwargs"].contains("reasoning_effort")) {
+    if (!body["chat_template_kwargs"]["reasoning_effort"].is_string()) {
+      return foundation::Err<std::string>(
+          foundation::ErrorCode::InvalidArgument,
+          "chat_template_kwargs.reasoning_effort must be a string");
+    }
+    requested =
+        body["chat_template_kwargs"]["reasoning_effort"].get<std::string>();
+  } else if (body.contains("reasoning_effort")) {
+    if (!body["reasoning_effort"].is_string()) {
+      return foundation::Err<std::string>(
+          foundation::ErrorCode::InvalidArgument,
+          "reasoning_effort must be a string");
+    }
+    requested = body["reasoning_effort"].get<std::string>();
+  } else if (info.reasoning.supported &&
+             !info.reasoning.default_effort.empty()) {
+    requested = info.reasoning.default_effort;
+  }
+  if (!requested) return foundation::Ok(std::string{});
+  if (!info.reasoning.supported) {
+    return foundation::Err<std::string>(
+        foundation::ErrorCode::InvalidArgument,
+        "model does not support reasoning effort: " + info.name);
+  }
+
+  std::string resolved = *requested;
+  if (const auto alias = info.reasoning.aliases.find(resolved);
+      alias != info.reasoning.aliases.end()) {
+    resolved = alias->second;
+  }
+  if (resolved == "none") {
+    if (!info.reasoning.none_disables) {
+      return foundation::Err<std::string>(
+          foundation::ErrorCode::InvalidArgument,
+          "reasoning effort 'none' is not supported by model: " + info.name);
+    }
+    inputs.enable_thinking = false;
+    inputs.chat_template_kwargs.erase("reasoning_effort");
+  } else {
+    if (std::find(info.reasoning.efforts.begin(), info.reasoning.efforts.end(),
+                  resolved) == info.reasoning.efforts.end()) {
+      return foundation::Err<std::string>(
+          foundation::ErrorCode::InvalidArgument,
+          "unsupported reasoning effort '" + *requested + "' for model: " +
+              info.name);
+    }
+    inputs.chat_template_kwargs["reasoning_effort"] =
+        nlohmann::json(resolved).dump();
+  }
+  return foundation::Ok(std::move(resolved));
+}
+
 std::string LlamaCppModel::version() {
   const char* info = llama_print_system_info();
   return info ? std::string(info) : std::string("unknown");
@@ -1429,6 +1489,15 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
       if (it->second == "true") inputs.enable_thinking = true;
       if (it->second == "false") inputs.enable_thinking = false;
     }
+  }
+  auto reasoning_effort = apply_reasoning_effort(inputs, body, info_);
+  if (!reasoning_effort) {
+    return Result<ChatTemplateResult>(std::unexpect,
+        make_error(reasoning_effort.error().code, reasoning_effort.error().message));
+  }
+  if (!reasoning_effort->empty()) {
+    LOG_INFO("reasoning_effort_applied", "model={} effort={}",
+             info_.name, *reasoning_effort);
   }
   if (body.contains("grammar") && body["grammar"].is_string()) {
     inputs.grammar = body["grammar"].get<std::string>();

--- a/libs/llama_cpp_wrapper/tests/test_llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/tests/test_llama_cpp_model.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -33,6 +34,54 @@ std::filesystem::path write_fake_gguf(const std::filesystem::path& dir) {
 
 TEST_CASE("LlamaCppModel: version string non-empty", "[llama][meta]") {
   REQUIRE_FALSE(LlamaCppModel::version().empty());
+}
+
+TEST_CASE("LlamaCppModel: reasoning effort reaches chat template inputs",
+          "[llama][reasoning]") {
+  ModelInfo info;
+  info.name = "reasoning-model";
+  info.reasoning.supported = true;
+  info.reasoning.efforts = {"low", "medium", "xhigh"};
+  info.reasoning.default_effort = "xhigh";
+  info.reasoning.none_disables = true;
+  info.reasoning.aliases = {{"high", "xhigh"}};
+
+  common_chat_templates_inputs inputs;
+  nlohmann::ordered_json body = {
+      {"reasoning_effort", "medium"},
+      {"chat_template_kwargs", {{"reasoning_effort", "low"}}},
+  };
+  auto effort = apply_reasoning_effort(inputs, body, info);
+  REQUIRE(effort);
+  CHECK(*effort == "low");
+  CHECK(inputs.chat_template_kwargs.at("reasoning_effort") == "\"low\"");
+
+  common_chat_templates_inputs alias_inputs;
+  effort = apply_reasoning_effort(
+      alias_inputs, nlohmann::ordered_json{{"reasoning_effort", "high"}}, info);
+  REQUIRE(effort);
+  CHECK(*effort == "xhigh");
+  CHECK(alias_inputs.chat_template_kwargs.at("reasoning_effort") == "\"xhigh\"");
+
+  common_chat_templates_inputs disabled_inputs;
+  disabled_inputs.enable_thinking = true;
+  effort = apply_reasoning_effort(
+      disabled_inputs, nlohmann::ordered_json{{"reasoning_effort", "none"}}, info);
+  REQUIRE(effort);
+  CHECK(*effort == "none");
+  CHECK_FALSE(disabled_inputs.enable_thinking);
+  CHECK_FALSE(disabled_inputs.chat_template_kwargs.contains("reasoning_effort"));
+}
+
+TEST_CASE("LlamaCppModel: unsupported reasoning effort is rejected",
+          "[llama][reasoning]") {
+  ModelInfo info;
+  info.name = "plain-model";
+  common_chat_templates_inputs inputs;
+  auto effort = apply_reasoning_effort(
+      inputs, nlohmann::ordered_json{{"reasoning_effort", "medium"}}, info);
+  REQUIRE_FALSE(effort);
+  CHECK(effort.error().code == ErrorCode::InvalidArgument);
 }
 
 TEST_CASE("LlamaCppModel: backend init/shutdown do not throw", "[llama][backend]") {

--- a/libs/model/include/model/model_info.hpp
+++ b/libs/model/include/model/model_info.hpp
@@ -33,6 +33,14 @@ struct ProfileOptimizationInfo {
     std::string schedule_window_end{"04:00"};
 };
 
+struct ReasoningConfig {
+    bool supported{false};
+    std::vector<std::string> efforts{};
+    std::string default_effort{};
+    bool none_disables{false};
+    std::map<std::string, std::string> aliases{};
+};
+
 struct ModelAlias {
     std::string name{};
     std::string target{};
@@ -70,6 +78,7 @@ struct ModelInfo {
     std::optional<double> completion_price_per_million{};
     std::map<std::string, std::string> artifacts{};
     SamplingConfig sampling{};
+    ReasoningConfig reasoning{};
     ProfileOptimizationInfo optimization{};
 
     [[nodiscard]] bool supports(const std::string& capability) const;

--- a/libs/observability/include/observability/gpu_telemetry.hpp
+++ b/libs/observability/include/observability/gpu_telemetry.hpp
@@ -4,12 +4,43 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <vector>
 
 namespace inferdeck::observability {
+
+namespace detail {
+
+struct GpuEngineCounterSample {
+  std::string instance;
+  double utilization_pct{};
+};
+
+class GpuUtilizationWindow {
+public:
+  explicit GpuUtilizationWindow(std::int64_t window_ms = 4000);
+  double add(std::int64_t timestamp_ms,
+             const std::vector<GpuEngineCounterSample>& samples);
+
+private:
+  struct Entry {
+    double duration_ms{};
+    std::unordered_map<std::string, double> engines;
+  };
+
+  std::int64_t window_ms_;
+  std::int64_t last_timestamp_ms_{};
+  double duration_ms_{};
+  bool initialized_{false};
+  std::deque<Entry> entries_;
+};
+
+}
 
 struct GpuStats {
   bool available{false};

--- a/libs/observability/src/gpu_telemetry.cpp
+++ b/libs/observability/src/gpu_telemetry.cpp
@@ -1,10 +1,12 @@
 #include "observability/gpu_telemetry.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <chrono>
 #include <cstddef>
 #include <cwchar>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #ifdef _WIN32
@@ -27,6 +29,16 @@ std::int64_t now_ms() {
   return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
+std::int64_t steady_ms() {
+  using namespace std::chrono;
+  return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+std::string gpu_engine_key(const std::string& instance) {
+  const auto luid = instance.find("luid_");
+  return luid == std::string::npos ? instance : instance.substr(luid);
+}
+
 #ifdef _WIN32
 std::string narrow(const wchar_t* value) {
   if (!value) return {};
@@ -43,14 +55,14 @@ std::string narrow(const wchar_t* value) {
   return out;
 }
 
-class PdhDoubleSumCounter {
+class PdhGpuEngineCounter {
 public:
-  explicit PdhDoubleSumCounter(const wchar_t* path) : path_(path) {}
-  ~PdhDoubleSumCounter() {
+  explicit PdhGpuEngineCounter(const wchar_t* path) : path_(path) {}
+  ~PdhGpuEngineCounter() {
     if (query_) PdhCloseQuery(query_);
   }
 
-  std::optional<double> read() {
+  std::optional<std::vector<detail::GpuEngineCounterSample>> read() {
     if (!ensure()) return std::nullopt;
     if (PdhCollectQueryData(query_) != ERROR_SUCCESS) return std::nullopt;
     DWORD buffer_size = 0;
@@ -61,11 +73,14 @@ public:
     auto items = reinterpret_cast<PDH_FMT_COUNTERVALUE_ITEM_W*>(buffer.data());
     status = PdhGetFormattedCounterArrayW(counter_, PDH_FMT_DOUBLE, &buffer_size, &item_count, items);
     if (status != ERROR_SUCCESS) return std::nullopt;
-    double total = 0.0;
+    std::vector<detail::GpuEngineCounterSample> samples;
+    samples.reserve(item_count);
     for (DWORD i = 0; i < item_count; ++i) {
-      if (items[i].FmtValue.CStatus == ERROR_SUCCESS) total += items[i].FmtValue.doubleValue;
+      if (items[i].FmtValue.CStatus == ERROR_SUCCESS) {
+        samples.push_back({narrow(items[i].szName), items[i].FmtValue.doubleValue});
+      }
     }
-    return std::clamp(total, 0.0, 100.0);
+    return samples;
   }
 
 private:
@@ -162,6 +177,54 @@ std::optional<std::pair<std::string, std::uint64_t>> read_dxgi_adapter() {
 
 } // namespace
 
+detail::GpuUtilizationWindow::GpuUtilizationWindow(std::int64_t window_ms)
+    : window_ms_(std::max<std::int64_t>(1, window_ms)) {}
+
+double detail::GpuUtilizationWindow::add(
+    std::int64_t timestamp_ms,
+    const std::vector<GpuEngineCounterSample>& samples) {
+  std::unordered_map<std::string, double> engines;
+  for (const auto& sample : samples) {
+    if (!std::isfinite(sample.utilization_pct) || sample.utilization_pct <= 0.0) continue;
+    engines[gpu_engine_key(sample.instance)] += sample.utilization_pct;
+  }
+  if (!initialized_) {
+    initialized_ = true;
+    last_timestamp_ms_ = timestamp_ms;
+    return 0.0;
+  }
+  if (timestamp_ms <= last_timestamp_ms_) return 0.0;
+
+  const double elapsed_ms = static_cast<double>(timestamp_ms - last_timestamp_ms_);
+  last_timestamp_ms_ = timestamp_ms;
+  entries_.push_back({elapsed_ms, std::move(engines)});
+  duration_ms_ += elapsed_ms;
+
+  while (!entries_.empty() && duration_ms_ > static_cast<double>(window_ms_)) {
+    const double excess = duration_ms_ - static_cast<double>(window_ms_);
+    if (entries_.front().duration_ms <= excess) {
+      duration_ms_ -= entries_.front().duration_ms;
+      entries_.pop_front();
+    } else {
+      entries_.front().duration_ms -= excess;
+      duration_ms_ -= excess;
+    }
+  }
+
+  if (duration_ms_ <= 0.0) return 0.0;
+  std::unordered_map<std::string, double> weighted;
+  for (const auto& entry : entries_) {
+    for (const auto& [engine, utilization] : entry.engines) {
+      weighted[engine] += utilization * entry.duration_ms;
+    }
+  }
+  double busiest = 0.0;
+  for (const auto& [_, total] : weighted) {
+    busiest = std::max(busiest, total / duration_ms_);
+  }
+  return std::clamp(busiest, 0.0, 100.0);
+}
+
 GpuTelemetry::GpuTelemetry() {
   latest_.available = false;
   latest_.reason = "no_helper_path";
@@ -240,8 +303,9 @@ void GpuTelemetry::record_external_sample(const GpuStats& s) {
 void GpuTelemetry::run_loop() {
   using namespace std::chrono;
 #ifdef _WIN32
-  PdhDoubleSumCounter gpu_util(L"\\GPU Engine(*)\\Utilization Percentage");
+  PdhGpuEngineCounter gpu_util(L"\\GPU Engine(*)\\Utilization Percentage");
   PdhLargeSumCounter dedicated_usage(L"\\GPU Adapter Memory(*)\\Dedicated Usage");
+  detail::GpuUtilizationWindow gpu_utilization;
   std::optional<std::pair<std::string, std::uint64_t>> adapter;
   auto next_adapter_refresh = steady_clock::time_point::min();
 #endif
@@ -259,7 +323,9 @@ void GpuTelemetry::run_loop() {
       s.available = true;
       s.provider = "windows_pdh_dxgi";
       s.gpu_name = adapter ? adapter->first : "Windows GPU";
-      s.utilization_pct = util.value_or(0.0);
+      s.utilization_pct = util
+          ? gpu_utilization.add(steady_ms(), *util)
+          : 0.0;
       s.vram_mb = used_bytes ? static_cast<double>(*used_bytes) / (1024.0 * 1024.0) : 0.0;
       if (adapter && adapter->second > 0) {
         const double total_mb = static_cast<double>(adapter->second) / (1024.0 * 1024.0);

--- a/libs/observability/tests/test_gpu_telemetry.cpp
+++ b/libs/observability/tests/test_gpu_telemetry.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <chrono>
 #include <thread>
@@ -8,6 +9,7 @@
 
 using namespace inferdeck::observability;
 using namespace std::chrono_literals;
+using Catch::Approx;
 
 namespace {
 
@@ -139,4 +141,39 @@ TEST_CASE("GpuTelemetry: blocking fetch wakes for a fresh external sample",
   REQUIRE(sample->provider == "test");
   REQUIRE(elapsed >= 10ms);
   REQUIRE(elapsed < 500ms);
+}
+
+TEST_CASE("GpuTelemetry: delayed engine accounting preserves utilization area",
+          "[observability][gpu]") {
+  detail::GpuUtilizationWindow window;
+  const std::string engine =
+      "pid_1_luid_0x00000000_0x00000001_phys_0_eng_0_engtype_compute";
+  REQUIRE(window.add(1000, {{engine, 0.0}}) == 0.0);
+  REQUIRE(window.add(2000, {{engine, 0.0}}) == 0.0);
+  REQUIRE(window.add(3000, {{engine, 0.0}}) == 0.0);
+  REQUIRE(window.add(4000, {{engine, 0.0}}) == 0.0);
+  REQUIRE(window.add(5000, {{engine, 400.0}}) == Approx(100.0));
+}
+
+TEST_CASE("GpuTelemetry: process contributions are grouped by physical engine",
+          "[observability][gpu]") {
+  detail::GpuUtilizationWindow window;
+  window.add(1000, {});
+  const double utilization = window.add(2000, {
+      {"pid_1_luid_0x0_0x1_phys_0_eng_0_engtype_compute", 40.0},
+      {"pid_2_luid_0x0_0x1_phys_0_eng_0_engtype_compute", 35.0},
+      {"pid_2_luid_0x0_0x1_phys_0_eng_1_engtype_copy", 60.0},
+  });
+  REQUIRE(utilization == Approx(75.0));
+}
+
+TEST_CASE("GpuTelemetry: final busiest-engine utilization is clamped",
+          "[observability][gpu]") {
+  detail::GpuUtilizationWindow window;
+  window.add(1000, {});
+  REQUIRE(window.add(2000, {
+      {"pid_1_luid_0x0_0x1_phys_0_eng_0_engtype_compute", 90.0},
+      {"pid_2_luid_0x0_0x1_phys_0_eng_0_engtype_compute", 80.0},
+      {"pid_2_luid_0x0_0x1_phys_0_eng_1_engtype_copy", 40.0},
+  }) == Approx(100.0));
 }


### PR DESCRIPTION
## Summary

- Smooth Windows PDH GPU utilization using rolling busiest-engine accounting.
- Add validated per-model and per-request reasoning effort to Chat Completions and Responses.
- Advertise reasoning capabilities through model discovery and document the OpenCode variants.
- Synchronize all first-party version fields and the committed dashboard bundle at InferDeck 0.7.2.

## Root cause

InferDeck clamped each 100 ms PDH sample before delayed driver accounting could be averaged, which produced spiky dashboard readings even during sustained multi-slot inference.

Reasoning effort was not modeled in configuration or forwarded consistently into llama.cpp chat-template inputs, so clients could not reliably select the supported effort level.

The embedded application and package versions also remained at 0.6.1 even though main had already advanced through the v0.7.1 release.

## Impact

GPU utilization now better matches Task Manager under sustained multi-slot load. Qwen3.8 clients can select `low`, `medium`, `xhigh`, or disable reasoning; `high` is retained as an alias for `xhigh`, and the configured default is `xhigh`.

The gateway, benchmark runner, dashboard, package metadata, tests, production bundle, and changelog now consistently report 0.7.2.

## Validation

- Release `inferdeck-gateway` build.
- 121 owned unit/integration tests; two environment-dependent tests were rerun successfully outside the sandbox.
- 186 focused assertions covering telemetry, config, routes, and llama.cpp reasoning.
- 34 dashboard tests and production dashboard build.
- Live Chat probes for `low`, `xhigh`, `high`, and disabled reasoning: HTTP 200.
- Live Responses probe for `medium`: HTTP 200.
- Invalid reasoning effort: HTTP 400.
- Live `/v1/models` discovery and resolved/applied effort logs verified.

No Git tag or GitHub release is created by this PR.

Closes #98
Closes #100