### PR TITLE
Phase 5: typed canonical inference domain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ add_subdirectory(${llama_cpp_SOURCE_DIR}/tools/mtmd EXCLUDE_FROM_ALL)
 
 # --- Our libraries and app ---
 add_subdirectory(libs/foundation)
+add_subdirectory(libs/inference)
 add_subdirectory(libs/model)
 add_subdirectory(libs/native_runtimes)
 add_subdirectory(libs/gateway)

--- a/apps/inferdeck-gateway/src/main.cpp
+++ b/apps/inferdeck-gateway/src/main.cpp
@@ -399,12 +399,12 @@ run_profile_benchmark_trial(
              "Answer directly and concisely. <|think_off|>"},
             {"user", prompts[index].prompt},
         };
-        request.max_tokens = prompts[index].max_tokens;
-        request.temperature = 0.0f;
-        request.top_p = 1.0f;
-        request.top_k = 0;
-        request.repeat_penalty = 1.0f;
-        request.seed = 4242 + static_cast<int>(index);
+        request.max_output_tokens = prompts[index].max_tokens;
+        request.sampling.temperature = 0.0f;
+        request.sampling.top_p = 1.0f;
+        request.sampling.top_k = 0;
+        request.sampling.repeat_penalty = 1.0f;
+        request.sampling.seed = 4242 + static_cast<int>(index);
         const auto started = std::chrono::steady_clock::now();
         std::atomic<bool> first_token{false};
         std::chrono::steady_clock::time_point first_token_at{};
@@ -478,12 +478,12 @@ run_profile_benchmark_trial(
          "separated by single spaces. Do not add punctuation or any "
          "other text."},
     };
-    speed_request.max_tokens = 192;
-    speed_request.temperature = 0.0f;
-    speed_request.top_p = 1.0f;
-    speed_request.top_k = 0;
-    speed_request.repeat_penalty = 1.0f;
-    speed_request.seed = 7001;
+    speed_request.max_output_tokens = 192;
+    speed_request.sampling.temperature = 0.0f;
+    speed_request.sampling.top_p = 1.0f;
+    speed_request.sampling.top_k = 0;
+    speed_request.sampling.repeat_penalty = 1.0f;
+    speed_request.sampling.seed = 7001;
     auto speed_result = runtime->predict_stream(
         *speed_slot, speed_request,
         [&](const model::InferenceDelta&) {
@@ -542,12 +542,12 @@ run_profile_benchmark_trial(
                              std::to_string(parallel_slots) + " request " +
                              std::to_string(index + 1) + "."},
                     };
-                    request.max_tokens = 144;
-                    request.temperature = 0.0f;
-                    request.top_p = 1.0f;
-                    request.top_k = 0;
-                    request.repeat_penalty = 1.0f;
-                    request.seed = 9000 + parallel_slots * 10 + index;
+                    request.max_output_tokens = 144;
+                    request.sampling.temperature = 0.0f;
+                    request.sampling.top_p = 1.0f;
+                    request.sampling.top_k = 0;
+                    request.sampling.repeat_penalty = 1.0f;
+                    request.sampling.seed = 9000 + parallel_slots * 10 + index;
                     auto result = runtime->predict_stream(
                         *slot, request,
                         [&](const model::InferenceDelta&) {

--- a/apps/model-tester/main.cpp
+++ b/apps/model-tester/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
     if (s1.has_value() && s2.has_value()) {
         InferenceRequest req;
         req.prompt = "hello";
-        req.max_tokens = 16;
+        req.max_output_tokens = 16;
         auto r1 = coord.predict("qwen3.6-27b", s1.value(), req);
         auto r2 = coord.predict("qwen3.6-27b", s2.value(), req);
         std::cout << "[model-tester] predict 1 ok=" << r1.has_value()

--- a/libs/gateway/CMakeLists.txt
+++ b/libs/gateway/CMakeLists.txt
@@ -3,7 +3,9 @@ project(gateway LANGUAGES CXX)
 
 set(GATEWAY_SOURCES
     src/streaming_sanitizer.cpp
+    src/generation_session.cpp
     src/routes.cpp
+    src/openai_adapter.cpp
     src/openai_routes.cpp
     src/anthropic_routes.cpp
     src/dashboard_routes.cpp

--- a/libs/gateway/include/gateway/generation_session.hpp
+++ b/libs/gateway/include/gateway/generation_session.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "foundation/result.hpp"
+#include "gateway/streaming_sanitizer.hpp"
+#include "model/backend_coordinator.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace inferdeck::foundation { class EventBus; }
+namespace inferdeck::observability { class Metrics; class StatsDb; }
+
+namespace inferdeck::gateway {
+
+class GenerationSession final {
+public:
+    GenerationSession(model::BackendCoordinator& coordinator,
+                      observability::Metrics* metrics,
+                      observability::StatsDb* stats_db,
+                      foundation::EventBus* events,
+                      int slot_id,
+                      std::string requested_model,
+                      std::string resolved_model,
+                      std::string reservation_key,
+                      std::uint64_t voice_session_token,
+                      int voice_session_grace_ms);
+    ~GenerationSession();
+
+    GenerationSession(const GenerationSession&) = delete;
+    GenerationSession& operator=(const GenerationSession&) = delete;
+
+    void start(model::InferenceRequest request);
+    foundation::Result<model::InferenceResult> run(
+        const model::InferenceRequest& request);
+    void finish_once(bool aborted_stream, int fallback_status,
+                     const std::string& reason);
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::deque<model::InferenceDelta> delta_queue;
+    std::size_t pending_bytes{0};
+    bool inference_done{false};
+    bool inference_error{false};
+    foundation::ErrorCode error_code{foundation::ErrorCode::Internal};
+    std::string error_msg;
+    std::shared_ptr<model::InferenceResult> final_result;
+    std::atomic<bool> aborted{false};
+    std::thread inference_thread;
+    int slot_id{-1};
+    std::string model_name;
+    std::string requested_model;
+    model::BackendCoordinator* coordinator{nullptr};
+    observability::Metrics* metrics{nullptr};
+    observability::StatsDb* stats_db{nullptr};
+    foundation::EventBus* events{nullptr};
+    std::atomic<bool> cleanup_done{false};
+    std::string reservation_key;
+    std::uint64_t voice_session_token{0};
+    int voice_session_grace_ms{0};
+    InferenceDeltaUtf8Buffer utf8;
+};
+
+}

--- a/libs/gateway/include/gateway/openai_adapter.hpp
+++ b/libs/gateway/include/gateway/openai_adapter.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "foundation/result.hpp"
+#include "model/imodel.hpp"
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace inferdeck::gateway {
+
+foundation::Result<model::InferenceRequest> parse_openai_chat_request(
+    const nlohmann::json& body, bool allow_extensions);
+
+}

--- a/libs/gateway/include/gateway/routes.hpp
+++ b/libs/gateway/include/gateway/routes.hpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace inferdeck::gateway {
@@ -25,11 +26,7 @@ enum class ComputeResource : std::uint8_t {
     Gpu,
 };
 
-enum class CompatibilityProfile : std::uint8_t {
-    StrictOpenAI,
-    OpenAIDerivative,
-    Anthropic,
-};
+using CompatibilityProfile = inference::CompatibilityProfile;
 
 struct GatewayDeps {
     model::BackendCoordinator& coordinator;
@@ -99,6 +96,17 @@ std::string serialize_chat_stream_terminal(const std::string& id,
                                            bool include_usage);
 std::string header_value(const httplib::Request& req, const std::string& name);
 std::string request_client_key(const httplib::Request& req);
+
+struct AcquiredGenerationSlot {
+    int slot_id{-1};
+    std::string reservation_key;
+    std::optional<std::uint64_t> voice_session_token;
+};
+
+std::optional<AcquiredGenerationSlot> acquire_generation_slot(
+    const httplib::Request& req, httplib::Response& resp,
+    const GatewayDeps& deps, const nlohmann::json& body,
+    const std::string& requested_model, const std::string& resolved_model);
 
 struct SwapStartResult {
     int status{200};

--- a/libs/gateway/src/anthropic_routes.cpp
+++ b/libs/gateway/src/anthropic_routes.cpp
@@ -1,6 +1,7 @@
 #include "gateway/anthropic_routes.hpp"
 
 #include "foundation/logging.hpp"
+#include "gateway/openai_adapter.hpp"
 #include "gateway/streaming_sanitizer.hpp"
 
 #include <algorithm>
@@ -669,22 +670,6 @@ nlohmann::json tool_use_block(const model::ToolCall& tc) {
     };
 }
 
-model::InferenceRequest make_inference_request_from(const nlohmann::json& openai_body) {
-    model::InferenceRequest ir;
-    ir.openai_body_json = openai_body.dump();
-    ir.max_tokens = openai_body.value(
-        "max_tokens", model::k_max_tokens_use_context_budget);
-    // Only carry sampler params the client explicitly set; unset ones fall back
-    // to the server-side SamplingConfig defaults downstream (issue #42).
-    if (openai_body.contains("temperature") && !openai_body["temperature"].is_null())
-        ir.temperature = openai_body["temperature"].get<float>();
-    if (openai_body.contains("top_p") && !openai_body["top_p"].is_null())
-        ir.top_p = openai_body["top_p"].get<float>();
-    if (openai_body.contains("top_k") && !openai_body["top_k"].is_null())
-        ir.top_k = openai_body["top_k"].get<int>();
-    return ir;
-}
-
 struct ErrorClass {
     int status;
     std::string type;
@@ -952,13 +937,13 @@ void handle_anthropic_messages(const httplib::Request& req, httplib::Response& r
         write_anthropic_error(resp, 400, "invalid_request_error", e.what());
         return;
     }
-    model::InferenceRequest ir;
-    try {
-        ir = make_inference_request_from(openai_body);
-    } catch (const std::exception& error) {
-        write_anthropic_error(resp, 400, "invalid_request_error", error.what());
+    auto inference_request = parse_openai_chat_request(openai_body, true);
+    if (!inference_request) {
+        write_anthropic_error(resp, 400, "invalid_request_error",
+                              inference_request.error().message);
         return;
     }
+    auto ir = std::move(*inference_request);
 
     const bool stream = body.value("stream", false);
 

--- a/libs/gateway/src/generation_session.cpp
+++ b/libs/gateway/src/generation_session.cpp
@@ -1,0 +1,194 @@
+#include "gateway/generation_session.hpp"
+
+#include "foundation/logging.hpp"
+#include "gateway/routes.hpp"
+
+#include <chrono>
+#include <exception>
+
+namespace inferdeck::gateway {
+using namespace inferdeck::foundation;
+
+namespace {
+
+constexpr std::size_t max_pending_stream_deltas = 128;
+constexpr std::size_t max_pending_stream_bytes = 1024 * 1024;
+
+std::size_t delta_size(const model::InferenceDelta& delta) {
+    std::size_t size = delta.content.size() + delta.reasoning_text.size();
+    for (const auto& call : delta.tool_calls) {
+        size += call.id.size() + call.type.size() + call.function_name.size() +
+                call.function_arguments.size();
+    }
+    return size;
+}
+
+}
+
+GenerationSession::GenerationSession(
+    model::BackendCoordinator& coordinator_value,
+    observability::Metrics* metrics_value,
+    observability::StatsDb* stats_db_value,
+    foundation::EventBus* events_value,
+    int slot_id_value,
+    std::string requested_model_value,
+    std::string resolved_model_value,
+    std::string reservation_key_value,
+    std::uint64_t voice_session_token_value,
+    int voice_session_grace_ms_value)
+    : slot_id(slot_id_value),
+      model_name(std::move(resolved_model_value)),
+      requested_model(std::move(requested_model_value)),
+      coordinator(&coordinator_value),
+      metrics(metrics_value),
+      stats_db(stats_db_value),
+      events(events_value),
+      reservation_key(std::move(reservation_key_value)),
+      voice_session_token(voice_session_token_value),
+      voice_session_grace_ms(voice_session_grace_ms_value) {}
+
+GenerationSession::~GenerationSession() {
+    finish_once(true, 499, "session_destroyed");
+}
+
+void GenerationSession::start(model::InferenceRequest request) {
+    inference_thread = std::thread([this, request = std::move(request)]() {
+        try {
+            auto result = coordinator->predict_stream(
+                model_name, slot_id, request,
+                [this](const model::InferenceDelta& delta) {
+                    if (aborted.load()) return false;
+                    const auto bytes = delta_size(delta);
+                    std::unique_lock lock(mtx);
+                    cv.wait(lock, [this, bytes] {
+                        const bool byte_capacity = delta_queue.empty() ||
+                            (bytes <= max_pending_stream_bytes &&
+                             pending_bytes <= max_pending_stream_bytes - bytes);
+                        return aborted.load() ||
+                            (delta_queue.size() < max_pending_stream_deltas &&
+                             byte_capacity);
+                    });
+                    if (aborted.load()) return false;
+                    delta_queue.push_back(delta);
+                    pending_bytes += bytes;
+                    lock.unlock();
+                    cv.notify_one();
+                    return !aborted.load();
+                },
+                &aborted);
+            {
+                std::lock_guard lock(mtx);
+                if (result) {
+                    final_result = std::make_shared<model::InferenceResult>(
+                        std::move(*result));
+                } else {
+                    inference_error = true;
+                    error_code = result.error().code;
+                    error_msg = result.error().message;
+                }
+                inference_done = true;
+            }
+            cv.notify_all();
+        } catch (const std::exception& error) {
+            LOG_ERROR("inference_thread_exception", "model={} slot_id={} what={}",
+                      model_name, slot_id, error.what());
+            std::lock_guard lock(mtx);
+            inference_error = true;
+            error_msg = error.what();
+            inference_done = true;
+            cv.notify_all();
+        } catch (...) {
+            LOG_ERROR("inference_thread_exception", "model={} slot_id={} what=unknown",
+                      model_name, slot_id);
+            std::lock_guard lock(mtx);
+            inference_error = true;
+            error_msg = "unknown exception";
+            inference_done = true;
+            cv.notify_all();
+        }
+    });
+}
+
+foundation::Result<model::InferenceResult> GenerationSession::run(
+    const model::InferenceRequest& request) {
+    try {
+        auto result = coordinator->predict(model_name, slot_id, request);
+        std::lock_guard lock(mtx);
+        inference_done = true;
+        if (result) {
+            final_result = std::make_shared<model::InferenceResult>(*result);
+        } else {
+            inference_error = true;
+            error_code = result.error().code;
+            error_msg = result.error().message;
+        }
+        return result;
+    } catch (const std::exception& error) {
+        std::lock_guard lock(mtx);
+        inference_done = true;
+        inference_error = true;
+        error_msg = error.what();
+        return foundation::Err<model::InferenceResult>(
+            foundation::ErrorCode::Internal, error.what());
+    } catch (...) {
+        std::lock_guard lock(mtx);
+        inference_done = true;
+        inference_error = true;
+        error_msg = "unknown exception";
+        return foundation::Err<model::InferenceResult>(
+            foundation::ErrorCode::Internal, error_msg);
+    }
+}
+
+void GenerationSession::finish_once(bool aborted_stream, int fallback_status,
+                                    const std::string& reason) {
+    bool expected = false;
+    if (!cleanup_done.compare_exchange_strong(expected, true)) return;
+    if (aborted_stream) aborted.store(true);
+    cv.notify_all();
+    if (inference_thread.joinable()) {
+        if (inference_thread.get_id() == std::this_thread::get_id()) {
+            inference_thread.detach();
+        } else {
+            inference_thread.join();
+        }
+    }
+
+    std::shared_ptr<model::InferenceResult> result;
+    bool error = false;
+    {
+        std::lock_guard lock(mtx);
+        result = final_result;
+        error = inference_error;
+    }
+    int status = fallback_status;
+    if (result && !aborted_stream && !error) {
+        status = 200;
+        record_request(metrics, stats_db, events, requested_model, *result,
+                       status, slot_id, 0.0, 0, model_name);
+    } else {
+        status = aborted_stream ? 499
+            : (error && fallback_status < 400 ? 500 : fallback_status);
+        record_request(metrics, stats_db, events, requested_model,
+                       model::InferenceResult{}, status, slot_id,
+                       0.0, 0, model_name);
+    }
+    LOG_INFO("stream_recorded", "model={} slot_id={} status={} reason={}",
+             model_name, slot_id, status, reason);
+    if (coordinator) {
+        auto released = coordinator->release_slot(model_name, slot_id);
+        if (!released) {
+            LOG_WARN("stream_cleanup_release_failed", "model={} slot_id={} reason={}",
+                     model_name, slot_id, released.error().message);
+        }
+        if (voice_session_token != 0) {
+            coordinator->complete_priority_session_hold(
+                reservation_key, voice_session_token,
+                std::chrono::milliseconds{voice_session_grace_ms});
+        }
+    }
+    LOG_INFO("stream_cleanup", "model={} slot_id={} aborted={} reason={}",
+             model_name, slot_id, aborted_stream, reason);
+}
+
+}

--- a/libs/gateway/src/openai_adapter.cpp
+++ b/libs/gateway/src/openai_adapter.cpp
@@ -1,0 +1,409 @@
+#include "gateway/openai_adapter.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <cctype>
+#include <limits>
+#include <string_view>
+
+namespace inferdeck::gateway {
+
+namespace {
+
+foundation::Result<model::InferenceRequest> invalid(std::string message) {
+    return foundation::Err<model::InferenceRequest>(
+        foundation::ErrorCode::InvalidArgument, std::move(message));
+}
+
+foundation::Result<std::vector<std::byte>> decode_base64(
+    std::string_view encoded) {
+    static constexpr std::string_view alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::array<int, 256> values{};
+    values.fill(-1);
+    for (std::size_t index = 0; index < alphabet.size(); ++index) {
+        values[static_cast<unsigned char>(alphabet[index])] =
+            static_cast<int>(index);
+    }
+    if (encoded.empty() || encoded.size() % 4 != 0) {
+        return foundation::Err<std::vector<std::byte>>(
+            foundation::ErrorCode::InvalidArgument,
+            "image_url contains invalid base64 length");
+    }
+    std::size_t padding = 0;
+    if (encoded.ends_with("==")) padding = 2;
+    else if (encoded.ends_with('=')) padding = 1;
+    const std::size_t data_size = encoded.size() - padding;
+    for (std::size_t index = 0; index < encoded.size(); ++index) {
+        const unsigned char character =
+            static_cast<unsigned char>(encoded[index]);
+        if (index >= data_size) {
+            if (character != '=') {
+                return foundation::Err<std::vector<std::byte>>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "image_url contains invalid base64 padding");
+            }
+        } else if (values[character] < 0) {
+            return foundation::Err<std::vector<std::byte>>(
+                foundation::ErrorCode::InvalidArgument,
+                "image_url contains invalid base64 data");
+        }
+    }
+    std::vector<std::byte> output;
+    output.reserve(encoded.size() / 4 * 3 - padding);
+    for (std::size_t index = 0; index < encoded.size(); index += 4) {
+        const int first = values[static_cast<unsigned char>(encoded[index])];
+        const int second = values[static_cast<unsigned char>(encoded[index + 1])];
+        const int third = encoded[index + 2] == '=' ? 0
+            : values[static_cast<unsigned char>(encoded[index + 2])];
+        const int fourth = encoded[index + 3] == '=' ? 0
+            : values[static_cast<unsigned char>(encoded[index + 3])];
+        if (first < 0 || second < 0 || third < 0 || fourth < 0) {
+            return foundation::Err<std::vector<std::byte>>(
+                foundation::ErrorCode::InvalidArgument,
+                "image_url contains invalid base64 data");
+        }
+        const std::uint32_t value =
+            (static_cast<std::uint32_t>(first) << 18) |
+            (static_cast<std::uint32_t>(second) << 12) |
+            (static_cast<std::uint32_t>(third) << 6) |
+            static_cast<std::uint32_t>(fourth);
+        output.push_back(static_cast<std::byte>((value >> 16) & 0xff));
+        if (encoded[index + 2] != '=') {
+            output.push_back(static_cast<std::byte>((value >> 8) & 0xff));
+        }
+        if (encoded[index + 3] != '=') {
+            output.push_back(static_cast<std::byte>(value & 0xff));
+        }
+    }
+    if ((padding == 1 &&
+         (values[static_cast<unsigned char>(encoded[data_size - 1])] & 0x3) != 0) ||
+        (padding == 2 &&
+         (values[static_cast<unsigned char>(encoded[data_size - 1])] & 0xf) != 0)) {
+        return foundation::Err<std::vector<std::byte>>(
+            foundation::ErrorCode::InvalidArgument,
+            "image_url contains non-canonical base64 padding");
+    }
+    if (output.empty()) {
+        return foundation::Err<std::vector<std::byte>>(
+            foundation::ErrorCode::InvalidArgument,
+            "image_url decoded to empty data");
+    }
+    return foundation::Ok(std::move(output));
+}
+
+foundation::Result<inference::Content> parse_image(
+    const nlohmann::json& part) {
+    if (!part.contains("image_url")) {
+        return foundation::Err<inference::Content>(
+            foundation::ErrorCode::InvalidArgument,
+            "image content requires image_url");
+    }
+    const auto& value = part["image_url"];
+    std::string url;
+    std::string detail;
+    if (value.is_string()) {
+        url = value.get<std::string>();
+    } else if (value.is_object() && value.contains("url") &&
+               value["url"].is_string()) {
+        url = value["url"].get<std::string>();
+        if (value.contains("detail") && value["detail"].is_string()) {
+            detail = value["detail"].get<std::string>();
+        }
+    } else {
+        return foundation::Err<inference::Content>(
+            foundation::ErrorCode::InvalidArgument,
+            "image_url must be a string or object with string url");
+    }
+    const auto comma = url.find(',');
+    if (comma == std::string::npos || !url.starts_with("data:image/") ||
+        url.substr(0, comma).find(";base64") == std::string::npos) {
+        return foundation::Err<inference::Content>(
+            foundation::ErrorCode::InvalidArgument,
+            "image_url must be a base64 data:image URL");
+    }
+    if (url.size() - comma - 1 > 32U * 1024U * 1024U) {
+        return foundation::Err<inference::Content>(
+            foundation::ErrorCode::InvalidArgument,
+            "image payload exceeds 32 MiB encoded");
+    }
+    auto bytes = decode_base64(std::string_view(url).substr(comma + 1));
+    if (!bytes) {
+        return foundation::Err<inference::Content>(bytes.error().code,
+                                                   bytes.error().message);
+    }
+    inference::ImageContent content;
+    content.bytes = std::move(*bytes);
+    content.media_type = url.substr(5, url.find(';') - 5);
+    content.detail = std::move(detail);
+    return foundation::Ok(inference::Content{std::move(content)});
+}
+
+foundation::Result<inference::Message> parse_message(
+    const nlohmann::json& value, bool allow_extensions) {
+    if (!value.is_object() || !value.contains("role") ||
+        !value["role"].is_string()) {
+        return foundation::Err<inference::Message>(
+            foundation::ErrorCode::InvalidArgument,
+            "messages entries require a string role");
+    }
+    const std::string role = value["role"].get<std::string>();
+    if (role != "developer" && role != "system" && role != "user" &&
+        role != "assistant" && role != "tool") {
+        return foundation::Err<inference::Message>(
+            foundation::ErrorCode::InvalidArgument,
+            "messages role is unsupported");
+    }
+    inference::Message message;
+    message.role = inference::Message::parse_role(role);
+    if (value.contains("name") && value["name"].is_string()) {
+        message.name = value["name"].get<std::string>();
+    }
+    if (value.contains("tool_call_id") && value["tool_call_id"].is_string()) {
+        message.tool_call_id = value["tool_call_id"].get<std::string>();
+    }
+    if (allow_extensions && value.contains("reasoning_content") &&
+        value["reasoning_content"].is_string()) {
+        message.reasoning = value["reasoning_content"].get<std::string>();
+    }
+    if (value.contains("content") && value["content"].is_string()) {
+        message.content.emplace_back(inference::TextContent{
+            value["content"].get<std::string>()});
+    } else if (value.contains("content") && value["content"].is_array()) {
+        for (const auto& part : value["content"]) {
+            if (!part.is_object() || !part.contains("type") ||
+                !part["type"].is_string()) {
+                return foundation::Err<inference::Message>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "message content parts require a string type");
+            }
+            const std::string type = part["type"].get<std::string>();
+            if (type == "text" || type == "input_text") {
+                if (!part.contains("text") || !part["text"].is_string()) {
+                    return foundation::Err<inference::Message>(
+                        foundation::ErrorCode::InvalidArgument,
+                        "text content requires string text");
+                }
+                message.content.emplace_back(inference::TextContent{
+                    part["text"].get<std::string>()});
+            } else if (type == "image" || type == "image_url" ||
+                       type == "input_image") {
+                auto content = parse_image(part);
+                if (!content) {
+                    return foundation::Err<inference::Message>(
+                        content.error().code, content.error().message);
+                }
+                message.content.push_back(std::move(*content));
+            } else {
+                return foundation::Err<inference::Message>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "message content type is unsupported: " + type);
+            }
+        }
+    } else if (value.contains("content") && !value["content"].is_null()) {
+        return foundation::Err<inference::Message>(
+            foundation::ErrorCode::InvalidArgument,
+            "message content must be a string, array, or null");
+    }
+    if (value.contains("tool_calls")) {
+        if (!value["tool_calls"].is_array()) {
+            return foundation::Err<inference::Message>(
+                foundation::ErrorCode::InvalidArgument,
+                "message tool_calls must be an array");
+        }
+        for (const auto& item : value["tool_calls"]) {
+            if (!item.is_object() || !item.contains("type") ||
+                !item["type"].is_string() ||
+                item["type"].get<std::string>() != "function" ||
+                !item.contains("function") ||
+                !item["function"].is_object()) {
+                return foundation::Err<inference::Message>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "message tool_calls entries require type function");
+            }
+            const auto& function = item["function"];
+            if (!function.contains("name") || !function["name"].is_string() ||
+                !function.contains("arguments")) {
+                return foundation::Err<inference::Message>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "message tool call requires name and arguments");
+            }
+            inference::FunctionCall call;
+            if (item.contains("id") && item["id"].is_string()) {
+                call.id = item["id"].get<std::string>();
+            }
+            call.name = function["name"].get<std::string>();
+            call.arguments = function["arguments"].is_string()
+                ? function["arguments"].get<std::string>()
+                : function["arguments"].dump();
+            message.tool_calls.push_back(std::move(call));
+        }
+    }
+    return foundation::Ok(std::move(message));
+}
+
+inference::ReasoningFormat reasoning_format(const std::string& value) {
+    if (value == "none") return inference::ReasoningFormat::None;
+    if (value == "deepseek") return inference::ReasoningFormat::DeepSeek;
+    if (value == "deepseek_legacy" || value == "deepseek-legacy") {
+        return inference::ReasoningFormat::DeepSeekLegacy;
+    }
+    return inference::ReasoningFormat::Automatic;
+}
+
+}
+
+foundation::Result<model::InferenceRequest> parse_openai_chat_request(
+    const nlohmann::json& body, bool allow_extensions) {
+    if (!body.is_object()) return invalid("request body must be an object");
+    if (!body.contains("messages") || !body["messages"].is_array()) {
+        return invalid("messages must be an array");
+    }
+    model::InferenceRequest request;
+    try {
+        request.max_output_tokens = body.value(
+            "max_tokens", body.value("max_completion_tokens",
+                                      inference::kUseContextBudget));
+        if (body.contains("temperature") && !body["temperature"].is_null()) {
+            request.sampling.temperature = body["temperature"].get<float>();
+        }
+        if (body.contains("top_p") && !body["top_p"].is_null()) {
+            request.sampling.top_p = body["top_p"].get<float>();
+        }
+        if (allow_extensions && body.contains("top_k") && !body["top_k"].is_null()) {
+            request.sampling.top_k = body["top_k"].get<int>();
+        }
+        if (allow_extensions && body.contains("min_p") && !body["min_p"].is_null()) {
+            request.sampling.min_p = body["min_p"].get<float>();
+        }
+        if (allow_extensions && body.contains("repeat_penalty") &&
+            !body["repeat_penalty"].is_null()) {
+            request.sampling.repeat_penalty = body["repeat_penalty"].get<float>();
+        }
+        if (allow_extensions && body.contains("repeat_last_n") &&
+            !body["repeat_last_n"].is_null()) {
+            request.sampling.repeat_last_n = body["repeat_last_n"].get<int>();
+        }
+        request.sampling.seed = body.value("seed", std::int64_t{-1});
+        request.parallel_tool_calls = body.value("parallel_tool_calls", true);
+        request.add_generation_prompt = allow_extensions
+            ? body.value("add_generation_prompt", true) : true;
+        if (allow_extensions && body.contains("reasoning_format") &&
+            body["reasoning_format"].is_string()) {
+            request.reasoning_format = reasoning_format(
+                body["reasoning_format"].get<std::string>());
+        }
+        if (body.contains("reasoning_effort") &&
+            body["reasoning_effort"].is_string()) {
+            request.reasoning_effort =
+                body["reasoning_effort"].get<std::string>();
+        } else if (allow_extensions && body.contains("chat_template_kwargs") &&
+                   body["chat_template_kwargs"].is_object() &&
+                   body["chat_template_kwargs"].contains("reasoning_effort") &&
+                   body["chat_template_kwargs"]["reasoning_effort"].is_string()) {
+            request.reasoning_effort = body["chat_template_kwargs"]
+                ["reasoning_effort"].get<std::string>();
+        }
+        if (allow_extensions && body.contains("chat_template_kwargs") &&
+            body["chat_template_kwargs"].is_object() &&
+            body["chat_template_kwargs"].contains("enable_thinking") &&
+            body["chat_template_kwargs"]["enable_thinking"].is_boolean()) {
+            request.enable_reasoning = body["chat_template_kwargs"]
+                ["enable_thinking"].get<bool>();
+        }
+    } catch (const nlohmann::json::exception& error) {
+        return invalid(error.what());
+    }
+    for (const auto& value : body["messages"]) {
+        auto message = parse_message(value, allow_extensions);
+        if (!message) return invalid(message.error().message);
+        request.messages.push_back(std::move(*message));
+    }
+    if (body.contains("tools")) {
+        if (!body["tools"].is_array()) return invalid("tools must be an array");
+        for (const auto& item : body["tools"]) {
+            if (!item.is_object() || item.value("type", "") != "function" ||
+                !item.contains("function") || !item["function"].is_object()) {
+                return invalid("tools entries must be function tools");
+            }
+            const auto& function = item["function"];
+            if (!function.contains("name") || !function["name"].is_string()) {
+                return invalid("function tools require a string name");
+            }
+            inference::FunctionTool tool;
+            tool.name = function["name"].get<std::string>();
+            if (function.contains("description") && function["description"].is_string()) {
+                tool.description = function["description"].get<std::string>();
+            }
+            if (function.contains("parameters")) {
+                tool.parameters_schema = function["parameters"].dump();
+            }
+            request.tools.push_back(std::move(tool));
+        }
+    }
+    if (body.contains("tool_choice") && !body["tool_choice"].is_null()) {
+        const auto& choice = body["tool_choice"];
+        if (choice.is_string()) {
+            const std::string value = choice.get<std::string>();
+            if (value == "none") request.tool_choice.kind = inference::ToolChoiceKind::None;
+            else if (value == "required") request.tool_choice.kind = inference::ToolChoiceKind::Required;
+            else if (value == "auto") request.tool_choice.kind = inference::ToolChoiceKind::Auto;
+            else return invalid("tool_choice string is unsupported");
+        } else if (choice.is_object() && choice.value("type", "") == "function" &&
+                   choice.contains("function") && choice["function"].is_object() &&
+                   choice["function"].contains("name") &&
+                   choice["function"]["name"].is_string()) {
+            request.tool_choice.kind = inference::ToolChoiceKind::Function;
+            request.tool_choice.function_name =
+                choice["function"]["name"].get<std::string>();
+        } else {
+            return invalid("tool_choice must be auto, none, required, or a function");
+        }
+    }
+    if (body.contains("stop") && !body["stop"].is_null()) {
+        if (body["stop"].is_string()) {
+            request.stop.push_back(body["stop"].get<std::string>());
+        } else if (body["stop"].is_array()) {
+            for (const auto& stop : body["stop"]) {
+                if (!stop.is_string()) return invalid("stop entries must be strings");
+                request.stop.push_back(stop.get<std::string>());
+            }
+        } else {
+            return invalid("stop must be a string or array of strings");
+        }
+    }
+    if (body.contains("response_format") && !body["response_format"].is_null()) {
+        if (!body["response_format"].is_object()) {
+            return invalid("response_format must be an object");
+        }
+        const auto& format = body["response_format"];
+        const std::string type = format.value("type", "text");
+        if (type == "json_object") {
+            request.output.kind = inference::StructuredOutputKind::JsonObject;
+            request.output.schema = format.contains("schema")
+                ? format["schema"].dump() : "{}";
+        } else if (type == "json_schema" && format.contains("json_schema") &&
+                   format["json_schema"].is_object()) {
+            const auto& schema = format["json_schema"];
+            request.output.kind = inference::StructuredOutputKind::JsonSchema;
+            request.output.name = schema.value("name", "");
+            request.output.description = schema.value("description", "");
+            request.output.strict = schema.value("strict", false);
+            if (schema.contains("schema")) request.output.schema = schema["schema"].dump();
+        } else if (type != "text") {
+            return invalid("response_format type is unsupported");
+        }
+    }
+    if (allow_extensions && body.contains("grammar") && body["grammar"].is_string()) {
+        request.output.kind = inference::StructuredOutputKind::Grammar;
+        request.output.schema = body["grammar"].get<std::string>();
+    } else if (allow_extensions && body.contains("json_schema") &&
+               !body["json_schema"].is_null()) {
+        request.output.kind = inference::StructuredOutputKind::JsonSchema;
+        request.output.schema = body["json_schema"].dump();
+    }
+    return foundation::Ok(std::move(request));
+}
+
+}

--- a/libs/gateway/src/openai_routes.cpp
+++ b/libs/gateway/src/openai_routes.cpp
@@ -1,4 +1,6 @@
 #include "gateway/openai_routes.hpp"
+#include "gateway/generation_session.hpp"
+#include "gateway/openai_adapter.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -671,57 +673,60 @@ nlohmann::json response_usage(const nlohmann::json& chat_usage) {
     };
 }
 
-nlohmann::json chat_to_response(const nlohmann::json& chat,
-                                const nlohmann::json& request,
-                                const std::string& response_id) {
-    const auto message = chat["choices"][0]["message"];
+
+nlohmann::json result_to_response(const model::InferenceResult& result,
+                                  const nlohmann::json& request,
+                                  const std::string& response_id,
+                                  const std::string& model_name) {
     nlohmann::json output = nlohmann::json::array();
-    if (message.contains("reasoning_content") && message["reasoning_content"].is_string() &&
-        !message["reasoning_content"].get<std::string>().empty()) {
+    if (!result.reasoning_text.empty()) {
         output.push_back({
-            {"id", make_id("rs_")}, {"type", "reasoning"}, {"status", "completed"},
-            {"summary", nlohmann::json::array()},
-            {"content", nlohmann::json::array({{{"type", "reasoning_text"},
-                                                  {"text", message["reasoning_content"]}}})},
+            {"id", make_id("rs_")}, {"type", "reasoning"},
+            {"status", "completed"}, {"summary", nlohmann::json::array()},
+            {"content", nlohmann::json::array({{
+                {"type", "reasoning_text"}, {"text", result.reasoning_text},
+            }})},
         });
     }
-    if (message.contains("content") && message["content"].is_string() &&
-        !message["content"].get<std::string>().empty()) {
+    if (!result.text.empty()) {
         output.push_back({
-            {"id", make_id("msg_")}, {"type", "message"}, {"status", "completed"},
-            {"role", "assistant"},
-            {"content", nlohmann::json::array({{{"type", "output_text"},
-                                                  {"text", message["content"]},
-                                                  {"annotations", nlohmann::json::array()}}})},
+            {"id", make_id("msg_")}, {"type", "message"},
+            {"status", "completed"}, {"role", "assistant"},
+            {"content", nlohmann::json::array({{
+                {"type", "output_text"}, {"text", result.text},
+                {"annotations", nlohmann::json::array()},
+            }})},
         });
     }
-    for (const auto& tool : message.value("tool_calls", nlohmann::json::array())) {
-        const std::string call_id = tool.value("id", make_id("call_"));
-        const auto function = tool.value("function", nlohmann::json::object());
+    for (const auto& tool : result.tool_calls) {
         output.push_back({
-            {"id", make_id("fc_")}, {"type", "function_call"}, {"status", "completed"},
-            {"call_id", call_id}, {"name", function.value("name", "")},
-            {"arguments", function.value("arguments", "")},
+            {"id", make_id("fc_")}, {"type", "function_call"},
+            {"status", "completed"},
+            {"call_id", tool.id.empty() ? make_id("call_") : tool.id},
+            {"name", tool.function_name},
+            {"arguments", tool.function_arguments},
         });
     }
     return {
-        {"id", response_id},
-        {"object", "response"},
-        {"created_at", std::time(nullptr)},
-        {"status", "completed"},
-        {"error", nullptr},
-        {"incomplete_details", nullptr},
+        {"id", response_id}, {"object", "response"},
+        {"created_at", std::time(nullptr)}, {"status", "completed"},
+        {"error", nullptr}, {"incomplete_details", nullptr},
         {"instructions", request.value("instructions", nlohmann::json(nullptr))},
         {"max_output_tokens", request.value("max_output_tokens", nlohmann::json(nullptr))},
-        {"model", chat.value("model", request.value("model", ""))},
-        {"output", output},
+        {"model", model_name}, {"output", output},
         {"parallel_tool_calls", request.value("parallel_tool_calls", true)},
         {"metadata", request.value("metadata", nlohmann::json::object())},
         {"temperature", request.value("temperature", 1.0)},
         {"top_p", request.value("top_p", 1.0)},
         {"tools", request.value("tools", nlohmann::json::array())},
         {"tool_choice", request.value("tool_choice", nlohmann::json("auto"))},
-        {"usage", response_usage(chat.value("usage", nlohmann::json::object()))},
+        {"usage", {
+            {"input_tokens", result.prompt_tokens},
+            {"input_tokens_details", {{"cached_tokens", result.cached_prompt_tokens}}},
+            {"output_tokens", result.completion_tokens},
+            {"output_tokens_details", {{"reasoning_tokens", 0}}},
+            {"total_tokens", result.prompt_tokens + result.completion_tokens},
+        }},
     };
 }
 
@@ -735,7 +740,7 @@ struct ToolStreamState {
 };
 
 struct ResponsesStreamState {
-    std::shared_ptr<httplib::Response> inner;
+    std::shared_ptr<GenerationSession> session;
     nlohmann::json request;
     std::string response_id;
     std::string model;
@@ -751,7 +756,6 @@ struct ResponsesStreamState {
     std::string reasoning;
     std::map<std::size_t, ToolStreamState> tools;
     nlohmann::json usage = nlohmann::json::object();
-    std::string pending;
 };
 
 nlohmann::json stream_response_object(const ResponsesStreamState& state,
@@ -829,66 +833,69 @@ bool ensure_reasoning_stream(ResponsesStreamState& state, httplib::DataSink& sin
     });
 }
 
-bool apply_chat_delta(ResponsesStreamState& state, httplib::DataSink& sink,
-                      const nlohmann::json& chunk) {
-    if (chunk.contains("usage") && chunk["usage"].is_object()) state.usage = chunk["usage"];
-    if (!chunk.contains("choices") || chunk["choices"].empty()) return true;
-    const auto delta = chunk["choices"][0].value("delta", nlohmann::json::object());
-    if (delta.contains("reasoning_content") && delta["reasoning_content"].is_string()) {
+bool apply_sanitized_generation_delta(ResponsesStreamState& state,
+                                      httplib::DataSink& sink,
+                                      const model::InferenceDelta& delta) {
+    if (!delta.reasoning_text.empty()) {
         if (!ensure_reasoning_stream(state, sink)) return false;
-        const std::string text = delta["reasoning_content"].get<std::string>();
-        state.reasoning += text;
+        state.reasoning += delta.reasoning_text;
         if (!emit_response_event(state, sink, {
-            {"type", "response.reasoning_text.delta"}, {"item_id", state.reasoning_id},
-            {"output_index", *state.reasoning_index}, {"content_index", 0}, {"delta", text},
+            {"type", "response.reasoning_text.delta"},
+            {"item_id", state.reasoning_id},
+            {"output_index", *state.reasoning_index}, {"content_index", 0},
+            {"delta", delta.reasoning_text},
         })) return false;
     }
-    if (delta.contains("content") && delta["content"].is_string()) {
+    if (!delta.content.empty()) {
         if (!ensure_message_stream(state, sink)) return false;
-        const std::string text = delta["content"].get<std::string>();
-        state.text += text;
+        state.text += delta.content;
         if (!emit_response_event(state, sink, {
-            {"type", "response.output_text.delta"}, {"item_id", state.message_id},
-            {"output_index", *state.message_index}, {"content_index", 0}, {"delta", text},
+            {"type", "response.output_text.delta"},
+            {"item_id", state.message_id},
+            {"output_index", *state.message_index}, {"content_index", 0},
+            {"delta", delta.content},
         })) return false;
     }
-    for (const auto& tool_delta : delta.value("tool_calls", nlohmann::json::array())) {
-        const std::size_t source_index = tool_delta.value("index", 0U);
-        const auto function = tool_delta.value("function", nlohmann::json::object());
-        auto [iterator, inserted] = state.tools.try_emplace(source_index);
+    for (const auto& source : delta.tool_calls) {
+        auto [iterator, inserted] = state.tools.try_emplace(source.index);
         auto& tool = iterator->second;
         if (inserted) {
-            tool.source_index = source_index;
+            tool.source_index = source.index;
             tool.output_index = state.next_output_index++;
             tool.item_id = make_id("fc_");
-            tool.call_id = tool_delta.value("id", make_id("call_"));
-            tool.name = function.value("name", "");
+            tool.call_id = source.id.empty() ? make_id("call_") : source.id;
+            tool.name = source.function_name;
             const nlohmann::json item = {
-                {"id", tool.item_id}, {"type", "function_call"}, {"status", "in_progress"},
-                {"call_id", tool.call_id}, {"name", tool.name}, {"arguments", ""},
+                {"id", tool.item_id}, {"type", "function_call"},
+                {"status", "in_progress"}, {"call_id", tool.call_id},
+                {"name", tool.name}, {"arguments", ""},
             };
             if (!emit_response_event(state, sink, {
-                {"type", "response.output_item.added"}, {"output_index", tool.output_index},
-                {"item", item},
+                {"type", "response.output_item.added"},
+                {"output_index", tool.output_index}, {"item", item},
             })) return false;
+        } else {
+            if (!source.id.empty()) tool.call_id = source.id;
+            if (!source.function_name.empty()) tool.name += source.function_name;
         }
-        if (tool_delta.contains("id") && tool_delta["id"].is_string()) {
-            tool.call_id = tool_delta["id"].get<std::string>();
-        }
-        if (!inserted && function.contains("name") && function["name"].is_string()) {
-            tool.name += function["name"].get<std::string>();
-        }
-        if (function.contains("arguments") && function["arguments"].is_string()) {
-            const std::string arguments = function["arguments"].get<std::string>();
-            tool.arguments += arguments;
+        if (!source.function_arguments.empty()) {
+            tool.arguments += source.function_arguments;
             if (!emit_response_event(state, sink, {
                 {"type", "response.function_call_arguments.delta"},
-                {"item_id", tool.item_id}, {"output_index", tool.output_index},
-                {"delta", arguments},
+                {"item_id", tool.item_id},
+                {"output_index", tool.output_index},
+                {"delta", source.function_arguments},
             })) return false;
         }
     }
     return true;
+}
+
+bool apply_generation_delta(ResponsesStreamState& state,
+                            httplib::DataSink& sink,
+                            const model::InferenceDelta& source) {
+    return apply_sanitized_generation_delta(
+        state, sink, state.session->utf8.on_delta(source));
 }
 
 nlohmann::json completed_stream_output(const ResponsesStreamState& state) {
@@ -978,48 +985,6 @@ bool fail_response_stream(ResponsesStreamState& state, httplib::DataSink& sink,
     return emit_response_event(state, sink, {{"type", "response.failed"}, {"response", response}});
 }
 
-bool consume_chat_sse(ResponsesStreamState& state, httplib::DataSink& sink,
-                      std::string_view bytes) {
-    state.pending.append(bytes);
-    std::size_t boundary = 0;
-    while ((boundary = state.pending.find("\n\n")) != std::string::npos) {
-        std::string frame = state.pending.substr(0, boundary);
-        state.pending.erase(0, boundary + 2);
-        if (frame.starts_with(':')) {
-            const std::string heartbeat = frame + "\n\n";
-            if (!sink.write(heartbeat.data(), heartbeat.size())) return false;
-            continue;
-        }
-        std::string data;
-        std::size_t line_start = 0;
-        while (line_start <= frame.size()) {
-            const auto line_end = frame.find('\n', line_start);
-            const std::string_view line(frame.data() + line_start,
-                (line_end == std::string::npos ? frame.size() : line_end) - line_start);
-            if (line.starts_with("data: ")) data.append(line.substr(6));
-            if (line_end == std::string::npos) break;
-            line_start = line_end + 1;
-        }
-        if (data.empty()) continue;
-        if (data == "[DONE]") {
-            if (!finish_response_stream(state, sink)) return false;
-            continue;
-        }
-        nlohmann::json chunk;
-        try {
-            chunk = nlohmann::json::parse(data);
-        } catch (const std::exception& error) {
-            return fail_response_stream(state, sink,
-                {{"code", "stream_parse_error"}, {"message", error.what()}});
-        }
-        if (chunk.contains("error")) {
-            if (!fail_response_stream(state, sink, chunk["error"])) return false;
-            continue;
-        }
-        if (!apply_chat_delta(state, sink, chunk)) return false;
-    }
-    return true;
-}
 
 } // namespace
 
@@ -1196,66 +1161,172 @@ void handle_responses(const httplib::Request& req, httplib::Response& resp,
                     "model does not support Responses API: " + model_name);
         return;
     }
-    httplib::Request chat_request = req;
-    chat_request.body = chat_body->dump();
-    httplib::Response chat_response;
-    auto chat_deps = deps;
-    chat_deps.compatibility_profile = CompatibilityProfile::OpenAIDerivative;
-    handle_chat_completions(chat_request, chat_response, chat_deps);
-    if (chat_response.status >= 400 ||
-        (!request.value("stream", false) && chat_response.body.empty())) {
-        resp = std::move(chat_response);
+    const bool stream = request.value("stream", false);
+    auto inference_request = parse_openai_chat_request(*chat_body, true);
+    if (!inference_request) {
+        write_error(resp, 400, "invalid_request_error",
+                    inference_request.error().message);
         return;
     }
-
-    const std::string response_id = make_id("resp_");
-    if (!request.value("stream", false)) {
-        try {
-            const auto chat = nlohmann::json::parse(chat_response.body);
-            write_json(resp, 200, chat_to_response(chat, request, response_id));
-        } catch (const std::exception&) {
-            write_error(resp, 500, "response_translation_failed",
-                        "invalid Chat Completions response");
+    if (!stream) {
+        auto acquired = acquire_generation_slot(
+            req, resp, deps, *chat_body, requested_model, model_name);
+        if (!acquired) return;
+        GenerationSession session(
+            deps.coordinator, deps.metrics, deps.stats_db, deps.events,
+            acquired->slot_id, requested_model, model_name,
+            acquired->reservation_key,
+            acquired->voice_session_token.value_or(0),
+            deps.voice_session_grace_ms);
+        auto result = session.run(*inference_request);
+        if (!result) {
+            const bool invalid =
+                result.error().code == foundation::ErrorCode::InvalidArgument ||
+                result.error().code == foundation::ErrorCode::ParseError ||
+                result.error().code == foundation::ErrorCode::ContextLengthExceeded;
+            const int status = invalid ? 400 : 500;
+            const std::string code =
+                result.error().code == foundation::ErrorCode::ContextLengthExceeded
+                    ? "context_length_exceeded"
+                    : (invalid ? "invalid_request_error" : "inference_error");
+            write_error(resp, status, code, result.error().message);
+            session.finish_once(false, status, "inference_error");
+            return;
         }
+        write_json(resp, 200, result_to_response(
+            *result, request, make_id("resp_"), requested_model));
+        session.finish_once(false, 200, "completed");
         return;
     }
-
-    if (!chat_response.content_provider_) {
-        resp = std::move(chat_response);
-        return;
-    }
+    auto acquired = acquire_generation_slot(
+        req, resp, deps, *chat_body, requested_model, model_name);
+    if (!acquired) return;
+    auto session = std::make_shared<GenerationSession>(
+        deps.coordinator, deps.metrics, deps.stats_db, deps.events,
+        acquired->slot_id, requested_model, model_name,
+        acquired->reservation_key,
+        acquired->voice_session_token.value_or(0),
+        deps.voice_session_grace_ms);
     auto state = std::make_shared<ResponsesStreamState>();
-    state->inner = std::make_shared<httplib::Response>(std::move(chat_response));
+    state->session = session;
     state->request = request;
-    state->response_id = response_id;
+    state->response_id = make_id("resp_");
     state->model = model_name;
+    session->start(std::move(*inference_request));
 
     resp.status = 200;
     resp.set_header("Cache-Control", "no-cache");
     resp.set_header("Connection", "keep-alive");
     resp.set_chunked_content_provider(
         "text/event-stream",
-        [state](std::size_t offset, httplib::DataSink& sink) {
-            if (!start_response_stream(*state, sink)) return false;
-            httplib::DataSink proxy;
-            proxy.write = [state, &sink](const char* data, std::size_t size) {
-                return consume_chat_sse(*state, sink, std::string_view(data, size));
-            };
-            proxy.is_writable = [&sink] { return sink.is_writable(); };
-            proxy.done = [] {};
-            proxy.done_with_trailer = [](const httplib::Headers&) {};
-            const bool more = state->inner->content_provider_(offset, 0, proxy);
-            if (!more && !state->completed) {
-                if (!finish_response_stream(*state, sink)) return false;
-            }
-            if (!more) {
+        [state](std::size_t, httplib::DataSink& sink) {
+            try {
+                if (!start_response_stream(*state, sink)) {
+                    state->session->finish_once(true, 499, "start_write_failed");
+                    return false;
+                }
+                std::unique_lock lock(state->session->mtx);
+                while (!state->session->cv.wait_for(
+                    lock, std::chrono::seconds{2}, [&] {
+                        return !state->session->delta_queue.empty() ||
+                               state->session->inference_done ||
+                               state->session->aborted.load();
+                    })) {
+                    lock.unlock();
+                    if (!sink.write(": \n\n", 4)) {
+                        state->session->finish_once(
+                            true, 499, "heartbeat_write_failed");
+                        return false;
+                    }
+                    lock.lock();
+                }
+                if (state->session->aborted.load() &&
+                    !state->session->inference_done &&
+                    state->session->delta_queue.empty()) {
+                    lock.unlock();
+                    state->session->finish_once(true, 499, "aborted");
+                    return false;
+                }
+                if (!state->session->delta_queue.empty()) {
+                    std::deque<model::InferenceDelta> deltas;
+                    deltas.swap(state->session->delta_queue);
+                    state->session->pending_bytes = 0;
+                    lock.unlock();
+                    state->session->cv.notify_all();
+                    if (!sink.is_writable()) {
+                        state->session->finish_once(
+                            true, 499, "sink_not_writable");
+                        return false;
+                    }
+                    for (const auto& delta : deltas) {
+                        if (!apply_generation_delta(*state, sink, delta)) {
+                            state->session->finish_once(
+                                true, 499, "chunk_write_failed");
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                const bool inference_error = state->session->inference_error;
+                const auto error_code = state->session->error_code;
+                const auto error_message = state->session->error_msg;
+                const auto result = state->session->final_result;
+                lock.unlock();
+
+                const auto trailing = state->session->utf8.finish();
+                if (!apply_sanitized_generation_delta(*state, sink, trailing)) {
+                    state->session->finish_once(
+                        true, 499, "trailing_chunk_write_failed");
+                    return false;
+                }
+                if (inference_error) {
+                    const bool invalid =
+                        error_code == foundation::ErrorCode::InvalidArgument ||
+                        error_code == foundation::ErrorCode::ParseError ||
+                        error_code == foundation::ErrorCode::ContextLengthExceeded;
+                    const int status = invalid ? 400 : 500;
+                    const std::string code =
+                        error_code == foundation::ErrorCode::ContextLengthExceeded
+                            ? "context_length_exceeded"
+                            : (invalid ? "invalid_request_error" : "inference_error");
+                    if (!fail_response_stream(*state, sink, {
+                        {"code", code}, {"message", error_message},
+                    })) {
+                        state->session->finish_once(
+                            true, 499, "error_write_failed");
+                        return false;
+                    }
+                    state->session->finish_once(
+                        false, status, "inference_error");
+                } else {
+                    if (result) {
+                        state->usage = {
+                            {"prompt_tokens", result->prompt_tokens},
+                            {"prompt_tokens_details", {
+                                {"cached_tokens", result->cached_prompt_tokens},
+                            }},
+                            {"completion_tokens", result->completion_tokens},
+                        };
+                    }
+                    if (!finish_response_stream(*state, sink)) {
+                        state->session->finish_once(
+                            true, 499, "done_write_failed");
+                        return false;
+                    }
+                    state->session->finish_once(false, 200, "completed");
+                }
                 sink.done();
                 return false;
+            } catch (...) {
+                state->session->finish_once(
+                    true, 500, "provider_exception");
+                return false;
             }
-            return true;
         },
         [state](bool success) {
-            state->inner->content_provider_success_ = success;
+            state->session->finish_once(
+                !success, success ? 200 : 499,
+                success ? "resource_releaser_success" : "resource_releaser");
         });
 }
 

--- a/libs/gateway/src/routes.cpp
+++ b/libs/gateway/src/routes.cpp
@@ -1,5 +1,7 @@
 #include "gateway/routes.hpp"
 
+#include "gateway/openai_adapter.hpp"
+#include "gateway/generation_session.hpp"
 #include "gateway/streaming_sanitizer.hpp"
 #include "foundation/logging.hpp"
 
@@ -328,31 +330,6 @@ nlohmann::json tool_call_delta_json(const model::ToolCallDelta& tc) {
         out["function"] = fn;
     }
     return out;
-}
-
-foundation::Result<model::InferenceRequest> make_inference_request(
-    const nlohmann::json& body, bool allow_extensions) {
-    try {
-        model::InferenceRequest ir;
-        ir.openai_body_json = body.dump();
-        ir.max_tokens = body.value("max_tokens", body.value(
-            "max_completion_tokens", model::k_max_tokens_use_context_budget));
-        if (body.contains("temperature") && !body["temperature"].is_null())
-            ir.temperature = body["temperature"].get<float>();
-        if (body.contains("top_p") && !body["top_p"].is_null())
-            ir.top_p = body["top_p"].get<float>();
-        if (allow_extensions && body.contains("top_k") && !body["top_k"].is_null())
-            ir.top_k = body["top_k"].get<int>();
-        if (allow_extensions && body.contains("repeat_penalty") && !body["repeat_penalty"].is_null())
-            ir.repeat_penalty = body["repeat_penalty"].get<float>();
-        if (allow_extensions && body.contains("repeat_last_n") && !body["repeat_last_n"].is_null())
-            ir.repeat_last_n = body["repeat_last_n"].get<int>();
-        ir.seed = body.value("seed", -1);
-        return foundation::Ok(std::move(ir));
-    } catch (const nlohmann::json::exception& error) {
-        return foundation::Err<model::InferenceRequest>(
-            foundation::ErrorCode::InvalidArgument, error.what());
-    }
 }
 
 foundation::Result<std::optional<std::string>> normalize_reasoning_request(
@@ -886,43 +863,20 @@ std::optional<AcquiredChatSlot> acquire_chat_slot(
 void handle_non_stream_chat(
     httplib::Response& resp, const GatewayDeps& deps,
     const std::string& requested_model, const std::string& model_name,
-    int slot_id, const std::string& id,
+    const std::string& id, GenerationSession& session,
     const model::InferenceRequest& inference_request) {
-    model::InferenceResult result;
-    try {
-        auto predicted = deps.coordinator.predict(
-            model_name, slot_id, inference_request);
-        if (!predicted) {
-            const auto error = classify_inference_error(predicted.error().code);
-            LOG_ERROR("inference_failed",
-                      "model={} slot_id={} status={} code={} error={}",
-                      model_name, slot_id, error.status, error.code,
-                      predicted.error().message);
-            model::InferenceResult failed;
-            record_request(deps, requested_model, failed, error.status,
-                           slot_id, 0.0, 0, model_name);
-            write_error(resp, error.status, error.code,
-                        predicted.error().message);
-            return;
-        }
-        result = std::move(*predicted);
-    } catch (const std::exception& error) {
-        LOG_ERROR("predict_exception", "what={}", error.what());
-        model::InferenceResult failed;
-        record_request(deps, requested_model, failed, 500, slot_id,
-                       0.0, 0, model_name);
-        write_error(resp, 500, "inference_exception", error.what());
-        return;
-    } catch (...) {
-        LOG_ERROR("predict_unknown_exception", "");
-        model::InferenceResult failed;
-        record_request(deps, requested_model, failed, 500, slot_id,
-                       0.0, 0, model_name);
-        write_error(resp, 500, "inference_exception", "unknown exception");
+    auto predicted = session.run(inference_request);
+    if (!predicted) {
+        const auto error = classify_inference_error(predicted.error().code);
+        LOG_ERROR("inference_failed",
+                  "model={} slot_id={} status={} code={} error={}",
+                  model_name, session.slot_id, error.status, error.code,
+                  predicted.error().message);
+        write_error(resp, error.status, error.code, predicted.error().message);
+        session.finish_once(false, error.status, "inference_error");
         return;
     }
-    record_request(deps, requested_model, result, 200, slot_id,
-                   0.0, 0, model_name);
+    const auto& result = *predicted;
     nlohmann::json message = {
         {"role", "assistant"},
         {"content", result.text},
@@ -958,9 +912,24 @@ void handle_non_stream_chat(
             {"total_tokens", result.prompt_tokens + result.completion_tokens},
         }},
     });
+    session.finish_once(false, 200, "completed");
 }
 
 } // namespace
+
+std::optional<AcquiredGenerationSlot> acquire_generation_slot(
+    const httplib::Request& req, httplib::Response& resp,
+    const GatewayDeps& deps, const nlohmann::json& body,
+    const std::string& requested_model, const std::string& resolved_model) {
+    auto acquired = acquire_chat_slot(req, resp, deps, body,
+                                      requested_model, resolved_model);
+    if (!acquired) return std::nullopt;
+    return AcquiredGenerationSlot{
+        acquired->slot_id,
+        std::move(acquired->reservation_key),
+        std::move(acquired->voice_session_token),
+    };
+}
 
 void handle_chat_completions(const httplib::Request& req, httplib::Response& resp,
                              const GatewayDeps& deps) {
@@ -1060,14 +1029,14 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     const bool include_stream_usage = body.contains("stream_options") &&
         body["stream_options"].is_object() &&
         body["stream_options"].value("include_usage", false);
-    auto inference_request = make_inference_request(body, derivative);
+    auto inference_request = parse_openai_chat_request(body, derivative);
     if (!inference_request) {
         write_error(resp, 400, "invalid_request_error",
                     inference_request.error().message);
         return;
     }
 
-    auto acquired = acquire_chat_slot(
+    auto acquired = acquire_generation_slot(
         req, resp, deps, body, requested_model, model_name);
     if (!acquired) return;
     const int slot_id = acquired->slot_id;
@@ -1078,187 +1047,21 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
     const std::string stream_model = requested_model;
     const auto stream_created = static_cast<std::int64_t>(std::time(nullptr));
 
-    std::function<void()> release_slot = [slot_id, &deps, model_name,
-                                          reservation_key,
-                                          voice_session_token]() noexcept {
-        if (slot_id >= 0) {
-            (void)deps.coordinator.release_slot(model_name, slot_id);
-        }
-        if (voice_session_token) {
-            deps.coordinator.complete_priority_session_hold(
-                reservation_key, *voice_session_token,
-                std::chrono::milliseconds{deps.voice_session_grace_ms});
-        }
-    };
-    struct ReleaseGuard {
-        std::function<void()>* fn;
-        bool armed{true};
-        void disarm() { armed = false; }
-        ~ReleaseGuard() { if (armed && fn) (*fn)(); }
-    } guard{&release_slot};
+    auto state = std::make_shared<GenerationSession>(
+        deps.coordinator, deps.metrics, deps.stats_db, deps.events,
+        slot_id, requested_model, model_name, reservation_key,
+        voice_session_token.value_or(0), deps.voice_session_grace_ms);
 
     if (!stream) {
         handle_non_stream_chat(resp, deps, requested_model, model_name,
-                               slot_id, id, *inference_request);
+                               id, *state, *inference_request);
         return;
     }
 
     resp.set_header("Content-Type", "text/event-stream");
     resp.set_header("Cache-Control", "no-cache");
     resp.set_header("Connection", "keep-alive");
-
-    struct StreamState {
-        std::mutex mtx;
-        std::condition_variable cv;
-        std::deque<model::InferenceDelta> delta_queue;
-        std::size_t pending_bytes{0};
-        bool inference_done{false};
-        bool inference_error{false};
-        foundation::ErrorCode error_code{foundation::ErrorCode::Internal};
-        std::string error_msg;
-        std::shared_ptr<model::InferenceResult> final_result;
-        std::atomic<bool> aborted{false};
-        std::thread inference_thread;
-        int slot_id{-1};
-        std::string model_name;
-        std::string requested_model;
-        model::BackendCoordinator* coordinator{nullptr};
-        observability::Metrics* metrics{nullptr};
-        observability::StatsDb* stats_db{nullptr};
-        foundation::EventBus* events{nullptr};
-        std::atomic<bool> cleanup_done{false};
-        std::string reservation_key;
-        std::uint64_t voice_session_token{0};
-        int voice_session_grace_ms{0};
-        InferenceDeltaUtf8Buffer utf8;
-
-        void finish_once(bool aborted_stream, int fallback_status, const std::string& reason) {
-            bool expected = false;
-            if (!cleanup_done.compare_exchange_strong(expected, true)) return;
-            if (aborted_stream) {
-                aborted.store(true);
-            }
-            cv.notify_all();
-            if (inference_thread.joinable()) {
-                if (inference_thread.get_id() == std::this_thread::get_id()) {
-                    inference_thread.detach();
-                } else {
-                    inference_thread.join();
-                }
-            }
-
-            std::shared_ptr<model::InferenceResult> result;
-            bool error = false;
-            {
-                std::lock_guard<std::mutex> lk(mtx);
-                result = final_result;
-                error = inference_error;
-            }
-
-            int status = fallback_status;
-            if (result && !aborted_stream && !error) {
-                status = 200;
-                record_request(metrics, stats_db, events, requested_model, *result, status, slot_id,
-                               0.0, 0, model_name);
-            } else {
-                model::InferenceResult failed;
-                status = aborted_stream ? 499
-                       : (error && fallback_status < 400 ? 500 : fallback_status);
-                record_request(metrics, stats_db, events, requested_model, failed, status, slot_id,
-                               0.0, 0, model_name);
-            }
-
-            LOG_INFO("stream_recorded", "model={} slot_id={} status={} reason={}",
-                     model_name, slot_id, status, reason);
-            if (coordinator) {
-                auto released = coordinator->release_slot(model_name, slot_id);
-                if (!released) {
-                    LOG_WARN("stream_cleanup_release_failed", "model={} slot_id={} reason={}",
-                             model_name, slot_id, released.error().message);
-                }
-                if (voice_session_token != 0) {
-                    coordinator->complete_priority_session_hold(
-                        reservation_key, voice_session_token,
-                        std::chrono::milliseconds{voice_session_grace_ms});
-                }
-            }
-            LOG_INFO("stream_cleanup", "model={} slot_id={} aborted={} reason={}",
-                     model_name, slot_id, aborted_stream, reason);
-        }
-    };
-
-    auto state = std::make_shared<StreamState>();
-    state->slot_id = slot_id;
-    state->model_name = model_name;
-    state->requested_model = requested_model;
-    state->coordinator = &deps.coordinator;
-    state->metrics = deps.metrics;
-    state->stats_db = deps.stats_db;
-    state->events = deps.events;
-    state->reservation_key = reservation_key;
-    state->voice_session_token = voice_session_token.value_or(0);
-    state->voice_session_grace_ms = deps.voice_session_grace_ms;
-
-    state->inference_thread = std::thread(
-        [state, ir = std::move(*inference_request)]() {
-        try {
-            auto result = state->coordinator->predict_stream(
-                state->model_name, state->slot_id, ir,
-                [state](const model::InferenceDelta& delta) -> bool {
-                    if (state->aborted.load()) return false;
-                    {
-                        const auto bytes = delta_size(delta);
-                        std::unique_lock<std::mutex> lk(state->mtx);
-                        state->cv.wait(lk, [state, bytes] {
-                            const bool byte_capacity =
-                                state->delta_queue.empty() ||
-                                (bytes <= max_pending_stream_bytes &&
-                                 state->pending_bytes <=
-                                     max_pending_stream_bytes - bytes);
-                            return state->aborted.load() ||
-                                   (state->delta_queue.size() <
-                                        max_pending_stream_deltas &&
-                                    byte_capacity);
-                        });
-                        if (state->aborted.load()) return false;
-                        state->delta_queue.push_back(delta);
-                        state->pending_bytes += bytes;
-                    }
-                    state->cv.notify_one();
-                    return !state->aborted.load();
-                },
-            &state->aborted);
-            {
-                std::lock_guard<std::mutex> lk(state->mtx);
-                if (result) {
-                    state->final_result = std::make_shared<model::InferenceResult>(std::move(*result));
-                } else {
-                    state->inference_error = true;
-                    state->error_code = result.error().code;
-                    state->error_msg = result.error().message;
-                }
-                state->inference_done = true;
-            }
-            state->cv.notify_all();
-        } catch (const std::exception& e) {
-            LOG_ERROR("inference_thread_exception", "model={} slot_id={} what={}",
-                      state->model_name, state->slot_id, e.what());
-            std::lock_guard<std::mutex> lk(state->mtx);
-            state->inference_error = true;
-            state->error_msg = e.what();
-            state->inference_done = true;
-            state->cv.notify_all();
-        } catch (...) {
-            LOG_ERROR("inference_thread_exception", "model={} slot_id={} what=unknown",
-                      state->model_name, state->slot_id);
-            std::lock_guard<std::mutex> lk(state->mtx);
-            state->inference_error = true;
-            state->error_msg = "unknown exception";
-            state->inference_done = true;
-            state->cv.notify_all();
-        }
-    });
-    guard.disarm();
+    state->start(std::move(*inference_request));
 
     resp.set_chunked_content_provider(
         "text/event-stream",

--- a/libs/gateway/tests/test_routes.cpp
+++ b/libs/gateway/tests/test_routes.cpp
@@ -7,6 +7,7 @@
 #include "gateway/cors.hpp"
 #include "gateway/openai_routes.hpp"
 #include "gateway/media_routes.hpp"
+#include "gateway/openai_adapter.hpp"
 #include "gateway/route_manifest.hpp"
 #include "gateway/routes.hpp"
 #include "httplib.h"
@@ -18,6 +19,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -35,6 +37,146 @@ using namespace inferdeck::gateway;
 using inferdeck::foundation::ErrorCode;
 using inferdeck::foundation::Ok;
 using inferdeck::foundation::Result;
+
+TEST_CASE("OpenAI adapter produces canonical multimodal and tool inputs",
+          "[routes][adapter]") {
+    const nlohmann::json body = {
+        {"messages", nlohmann::json::array({
+            {{"role", "developer"}, {"content", "policy"}},
+            {{"role", "user"},
+             {"content", nlohmann::json::array({
+                 {{"type", "text"}, {"text", "describe"}},
+                 {{"type", "image_url"},
+                  {"image_url", {{"url", "data:image/png;base64,AQID"},
+                                 {"detail", "high"}}}}
+             })}}
+        })},
+        {"tools", nlohmann::json::array({
+            {{"type", "function"},
+             {"function", {{"name", "lookup"}, {"description", "find"}}}}
+        })}
+    };
+
+    const auto parsed = parse_openai_chat_request(body, false);
+    REQUIRE(parsed);
+    REQUIRE(parsed->messages.size() == 2);
+    CHECK(parsed->messages[0].role == inference::MessageRole::Developer);
+    REQUIRE(parsed->messages[1].content.size() == 2);
+    const auto* text =
+        std::get_if<inference::TextContent>(&parsed->messages[1].content[0]);
+    REQUIRE(text != nullptr);
+    CHECK(text->text == "describe");
+    const auto* image =
+        std::get_if<inference::ImageContent>(&parsed->messages[1].content[1]);
+    REQUIRE(image != nullptr);
+    CHECK(image->media_type == "image/png");
+    CHECK(image->detail == "high");
+    REQUIRE(image->bytes.size() == 3);
+    CHECK(std::to_integer<unsigned char>(image->bytes[0]) == 1);
+    CHECK(std::to_integer<unsigned char>(image->bytes[1]) == 2);
+    CHECK(std::to_integer<unsigned char>(image->bytes[2]) == 3);
+    REQUIRE(parsed->tools.size() == 1);
+    CHECK(parsed->tools[0].parameters_schema == "{}");
+}
+
+TEST_CASE("OpenAI adapter rejects malformed image base64",
+          "[routes][adapter][validation]") {
+    for (const std::string encoded : {"A===", "AA==junk", "AB==", "AAB="}) {
+        const nlohmann::json body = {
+            {"messages", nlohmann::json::array({
+                {{"role", "user"},
+                 {"content", nlohmann::json::array({
+                     {{"type", "image_url"},
+                      {"image_url", "data:image/png;base64," + encoded}}
+                 })}}
+            })}
+        };
+        INFO(encoded);
+        CHECK_FALSE(parse_openai_chat_request(body, false));
+    }
+}
+
+TEST_CASE("OpenAI adapter validates assistant tool call type",
+          "[routes][adapter][validation]") {
+    const auto request_with = [](const nlohmann::json& tool_call) {
+        return nlohmann::json{
+            {"messages", nlohmann::json::array({
+                {{"role", "assistant"},
+                 {"content", nullptr},
+                 {"tool_calls", nlohmann::json::array({tool_call})}}
+            })}
+        };
+    };
+    const nlohmann::json function = {
+        {"id", "call_1"},
+        {"function", {{"name", "lookup"}, {"arguments", "{}"}}}
+    };
+    CHECK_FALSE(parse_openai_chat_request(request_with(function), false));
+    auto unsupported = function;
+    unsupported["type"] = "custom";
+    CHECK_FALSE(parse_openai_chat_request(request_with(unsupported), false));
+    auto valid = function;
+    valid["type"] = "function";
+    CHECK(parse_openai_chat_request(request_with(valid), false));
+}
+
+TEST_CASE("Derivative OpenAI adapter preserves reasoning toggle",
+          "[routes][adapter][reasoning]") {
+    const nlohmann::json body = {
+        {"messages", nlohmann::json::array({
+            {{"role", "user"}, {"content", "answer"}}
+        })},
+        {"chat_template_kwargs", {{"enable_thinking", false}}}
+    };
+    const auto derivative = parse_openai_chat_request(body, true);
+    REQUIRE(derivative);
+    REQUIRE(derivative->enable_reasoning.has_value());
+    CHECK_FALSE(*derivative->enable_reasoning);
+    const auto strict = parse_openai_chat_request(body, false);
+    REQUIRE(strict);
+    CHECK_FALSE(strict->enable_reasoning.has_value());
+}
+
+TEST_CASE("OpenAI adapter matches the canonical golden fixture",
+          "[routes][adapter][golden]") {
+    const auto path = std::filesystem::path(INFERDECK_SOURCE_DIR) /
+        "tests/fixtures/openai_adapter_golden.json";
+    std::ifstream input(path, std::ios::binary);
+    REQUIRE(input.good());
+    const auto fixture = nlohmann::json::parse(input);
+    const auto parsed = parse_openai_chat_request(fixture["chat_request"], false);
+    REQUIRE(parsed);
+    const auto role_name = [](inference::MessageRole role) {
+        if (role == inference::MessageRole::Developer) return "developer";
+        if (role == inference::MessageRole::System) return "system";
+        if (role == inference::MessageRole::Assistant) return "assistant";
+        if (role == inference::MessageRole::Tool) return "tool";
+        return "user";
+    };
+    nlohmann::json actual;
+    actual["roles"] = nlohmann::json::array();
+    actual["texts"] = nlohmann::json::array();
+    for (const auto& message : parsed->messages) {
+        actual["roles"].push_back(role_name(message.role));
+        const auto* text = std::get_if<inference::TextContent>(&message.content[0]);
+        REQUIRE(text);
+        actual["texts"].push_back(text->text);
+    }
+    actual["max_output_tokens"] = parsed->max_output_tokens;
+    const auto snapshot_float = [](float value) {
+        return std::round(static_cast<double>(value) * 1'000'000.0) /
+               1'000'000.0;
+    };
+    actual["temperature"] = snapshot_float(*parsed->sampling.temperature);
+    actual["top_p"] = snapshot_float(*parsed->sampling.top_p);
+    actual["tool_name"] = parsed->tools[0].name;
+    actual["tool_schema"] = parsed->tools[0].parameters_schema;
+    actual["tool_choice"] = parsed->tool_choice.function_name;
+    actual["output_kind"] = "json_schema";
+    actual["output_name"] = parsed->output.name;
+    actual["output_strict"] = parsed->output.strict;
+    CHECK(actual == fixture["canonical"]);
+}
 
 namespace {
 
@@ -61,7 +203,7 @@ public:
     std::atomic<int> transcription_delay_ms{0};
     std::vector<int> busy_slots;
     mutable std::mutex mtx;
-    std::string last_request_json;
+    InferenceRequest last_request;
     ChatTemplateMeta chat_meta_{};
 
     explicit IModelMock(ModelInfo info) : model_info(std::move(info)) {
@@ -126,19 +268,17 @@ public:
     }
 
     Result<InferenceResult> predict(int, const InferenceRequest& request) override {
-        last_max_tokens.store(request.max_tokens);
+        last_max_tokens.store(request.max_output_tokens);
         {
             std::lock_guard<std::mutex> lock(mtx);
-            last_request_json = request.openai_body_json;
+            last_request = request;
         }
         if (context_error.load()) {
             return inferdeck::foundation::Err<InferenceResult>(
                 ErrorCode::ContextLengthExceeded, "prompt is too long");
         }
         InferenceResult r;
-        const auto body = request.openai_body_json.empty()
-            ? nlohmann::json::object() : nlohmann::json::parse(request.openai_body_json);
-        if (body.contains("tools") && !body["tools"].empty()) {
+        if (!request.tools.empty()) {
             r.reasoning_text = "need a tool";
             ToolCall call;
             call.id = "call_test";
@@ -159,7 +299,7 @@ public:
         const std::atomic<bool>* cancel = nullptr) override {
         {
             std::lock_guard<std::mutex> lock(mtx);
-            last_request_json = request.openai_body_json;
+            last_request = request;
         }
         if (context_error.load()) {
             return inferdeck::foundation::Err<InferenceResult>(
@@ -1097,9 +1237,7 @@ TEST_CASE("Routes: reasoning effort precedence and defaults reach inference",
     REQUIRE(response->status == 200);
     auto* model = dynamic_cast<const IModelMock*>(ts.coordinator.get_model(info.name));
     REQUIRE(model != nullptr);
-    auto request = nlohmann::json::parse(model->last_request_json);
-    CHECK(request["reasoning_effort"] == "low");
-    CHECK(request["chat_template_kwargs"]["reasoning_effort"] == "low");
+    CHECK(model->last_request.reasoning_effort == "low");
 
     response = client.Post("/v1/chat/completions", nlohmann::json{
         {"model", info.name},
@@ -1107,8 +1245,7 @@ TEST_CASE("Routes: reasoning effort precedence and defaults reach inference",
     }.dump(), "application/json");
     REQUIRE(response);
     REQUIRE(response->status == 200);
-    request = nlohmann::json::parse(model->last_request_json);
-    CHECK(request["reasoning_effort"] == "xhigh");
+    CHECK(model->last_request.reasoning_effort == "xhigh");
     ts.stop();
 }
 
@@ -1160,8 +1297,7 @@ TEST_CASE("Routes: Responses reasoning effort translates for streaming and non-s
     REQUIRE(response->status == 200);
     auto* model = dynamic_cast<const IModelMock*>(ts.coordinator.get_model(info.name));
     REQUIRE(model != nullptr);
-    CHECK(nlohmann::json::parse(model->last_request_json)["reasoning_effort"] ==
-          "medium");
+    CHECK(model->last_request.reasoning_effort == "medium");
 
     response = client.Post("/v1/responses", nlohmann::json{
         {"model", info.name}, {"input", "Hello"}, {"stream", true},
@@ -1169,8 +1305,7 @@ TEST_CASE("Routes: Responses reasoning effort translates for streaming and non-s
     }.dump(), "application/json");
     REQUIRE(response);
     REQUIRE(response->status == 200);
-    CHECK(nlohmann::json::parse(model->last_request_json)["reasoning_effort"] ==
-          "none");
+    CHECK(model->last_request.reasoning_effort == "none");
     ts.stop();
 }
 
@@ -1215,9 +1350,9 @@ TEST_CASE("Routes: POST /v1/responses maps structured output format", "[routes][
     REQUIRE(response->status == 200);
     auto* model = dynamic_cast<const IModelMock*>(ts.coordinator.get_model("chat-model"));
     REQUIRE(model != nullptr);
-    const auto translated = nlohmann::json::parse(model->last_request_json);
-    REQUIRE(translated["response_format"]["type"] == "json_schema");
-    REQUIRE(translated["response_format"]["json_schema"]["name"] == "answer");
+    REQUIRE(model->last_request.output.kind ==
+            inference::StructuredOutputKind::JsonSchema);
+    REQUIRE(model->last_request.output.name == "answer");
     ts.stop();
 }
 
@@ -1315,6 +1450,20 @@ TEST_CASE("Routes: POST /v1/responses streams typed reasoning and tool events", 
     REQUIRE(response->body.find("event: response.function_call_arguments.done") != std::string::npos);
     REQUIRE(response->body.find("event: response.completed") != std::string::npos);
     REQUIRE(response->body.find("data: [DONE]") == std::string::npos);
+    const auto fixture_path = std::filesystem::path(INFERDECK_SOURCE_DIR) /
+        "tests/fixtures/openai_adapter_golden.json";
+    std::ifstream fixture_input(fixture_path, std::ios::binary);
+    REQUIRE(fixture_input.good());
+    const auto fixture = nlohmann::json::parse(fixture_input);
+    nlohmann::json event_types = nlohmann::json::array();
+    std::size_t offset = 0;
+    while ((offset = response->body.find("event: ", offset)) != std::string::npos) {
+        const auto end = response->body.find('\n', offset);
+        REQUIRE(end != std::string::npos);
+        event_types.push_back(response->body.substr(offset + 7, end - offset - 7));
+        offset = end + 1;
+    }
+    CHECK(event_types == fixture["responses_event_types"]);
     ts.stop();
 }
 
@@ -2107,10 +2256,12 @@ TEST_CASE("Routes: vision models admit image input and preserve the payload",
     const auto* model = dynamic_cast<const IModelMock*>(
         ts.coordinator.get_backend("vision-model"));
     REQUIRE(model);
-    const auto body = nlohmann::json::parse(model->last_request_json);
-    CHECK(body["messages"][0]["content"][1]["type"] == "image_url");
-    CHECK(body["messages"][0]["content"][1]["image_url"]["url"] ==
-          "data:image/png;base64,AA==");
+    REQUIRE(model->last_request.messages.size() == 1);
+    REQUIRE(model->last_request.messages[0].content.size() == 2);
+    const auto* image = std::get_if<inference::ImageContent>(
+        &model->last_request.messages[0].content[1]);
+    REQUIRE(image);
+    CHECK(image->bytes == std::vector<std::byte>{std::byte{0}});
     CHECK(ts.metrics.total_requests() == 1);
     ts.stop();
 }

--- a/libs/inference/CMakeLists.txt
+++ b/libs/inference/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.27)
+project(inference LANGUAGES CXX)
+
+add_library(inference INTERFACE)
+
+target_include_directories(inference
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+target_compile_features(inference INTERFACE cxx_std_23)
+
+if(INFERDECK_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/libs/inference/include/inference/domain.hpp
+++ b/libs/inference/include/inference/domain.hpp
@@ -1,0 +1,300 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace inferdeck::inference {
+
+inline constexpr int kUseContextBudget = -1;
+
+enum class Principal : std::uint8_t {
+    Public,
+    DataPlane,
+    ControlRead,
+    ControlWrite,
+    Internal,
+};
+
+enum class Endpoint : std::uint8_t {
+    Chat,
+    Responses,
+    Embeddings,
+    Images,
+    Speech,
+    Transcriptions,
+    Internal,
+};
+
+enum class CompatibilityProfile : std::uint8_t {
+    StrictOpenAI,
+    OpenAIDerivative,
+    Anthropic,
+    Internal,
+};
+
+struct RequestContext {
+    std::string request_id;
+    Principal principal{Principal::Public};
+    Endpoint endpoint{Endpoint::Internal};
+    std::chrono::steady_clock::time_point deadline{};
+    std::function<bool()> cancelled;
+    std::string requested_model;
+    std::string resolved_model;
+    bool stream{false};
+    CompatibilityProfile compatibility_profile{
+        CompatibilityProfile::StrictOpenAI};
+};
+
+enum class MessageRole : std::uint8_t {
+    Developer,
+    System,
+    User,
+    Assistant,
+    Tool,
+};
+
+struct TextContent {
+    std::string text;
+};
+
+struct ImageContent {
+    std::vector<std::byte> bytes;
+    std::string media_type;
+    std::string detail;
+};
+
+struct AudioContent {
+    std::vector<std::byte> bytes;
+    std::string media_type;
+};
+
+using Content = std::variant<TextContent, ImageContent, AudioContent>;
+
+struct FunctionCall {
+    std::string id;
+    std::string name;
+    std::string arguments;
+};
+
+struct Message {
+    MessageRole role{MessageRole::User};
+    std::vector<Content> content;
+    std::vector<FunctionCall> tool_calls;
+    std::string reasoning;
+    std::string tool_call_id;
+    std::string name;
+
+    Message() = default;
+    Message(MessageRole message_role, std::string text)
+        : role(message_role) {
+        content.emplace_back(TextContent{std::move(text)});
+    }
+    Message(std::string_view message_role, std::string text)
+        : Message(parse_role(message_role), std::move(text)) {}
+
+    static MessageRole parse_role(std::string_view value) {
+        if (value == "developer") return MessageRole::Developer;
+        if (value == "system") return MessageRole::System;
+        if (value == "assistant") return MessageRole::Assistant;
+        if (value == "tool") return MessageRole::Tool;
+        return MessageRole::User;
+    }
+};
+
+struct FunctionTool {
+    std::string name;
+    std::string description;
+    std::string parameters_schema{"{}"};
+};
+
+enum class ToolChoiceKind : std::uint8_t {
+    Auto,
+    None,
+    Required,
+    Function,
+};
+
+struct ToolChoice {
+    ToolChoiceKind kind{ToolChoiceKind::Auto};
+    std::string function_name;
+};
+
+enum class StructuredOutputKind : std::uint8_t {
+    Text,
+    JsonObject,
+    JsonSchema,
+    Grammar,
+};
+
+struct StructuredOutput {
+    StructuredOutputKind kind{StructuredOutputKind::Text};
+    std::string name;
+    std::string description;
+    std::string schema;
+    bool strict{false};
+};
+
+enum class ReasoningFormat : std::uint8_t {
+    Automatic,
+    None,
+    DeepSeek,
+    DeepSeekLegacy,
+};
+
+struct Sampling {
+    std::optional<float> temperature;
+    std::optional<float> top_p;
+    std::optional<int> top_k;
+    std::optional<float> min_p;
+    std::optional<float> repeat_penalty;
+    std::optional<int> repeat_last_n;
+    std::int64_t seed{-1};
+};
+
+struct GenerationRequest {
+    std::string prompt;
+    std::vector<Message> messages;
+    std::vector<FunctionTool> tools;
+    ToolChoice tool_choice;
+    StructuredOutput output;
+    Sampling sampling;
+    std::vector<std::string> stop;
+    std::optional<std::string> reasoning_effort;
+    std::optional<bool> enable_reasoning;
+    int max_output_tokens{kUseContextBudget};
+    bool parallel_tool_calls{true};
+    bool add_generation_prompt{true};
+    ReasoningFormat reasoning_format{ReasoningFormat::Automatic};
+};
+
+struct SessionRequest {
+    RequestContext context;
+    GenerationRequest generation;
+};
+
+struct ToolCall {
+    std::string id;
+    std::string type{"function"};
+    std::string function_name;
+    std::string function_arguments;
+};
+
+struct ToolCallDelta {
+    std::size_t index{0};
+    std::string id;
+    std::string type;
+    std::string function_name;
+    std::string function_arguments;
+};
+
+struct GenerationDelta {
+    std::string content;
+    std::string reasoning_text;
+    std::vector<ToolCallDelta> tool_calls;
+};
+
+struct TextOutput {
+    std::string text;
+};
+
+struct ReasoningOutput {
+    std::string text;
+};
+
+struct ToolCallOutput {
+    ToolCall call;
+};
+
+struct ToolCallDeltaOutput {
+    ToolCallDelta call;
+};
+
+struct UsageOutput {
+    int input_tokens{0};
+    int cached_input_tokens{0};
+    int output_tokens{0};
+};
+
+struct FinishOutput {
+    std::string reason{"stop"};
+};
+
+struct RefusalOutput {
+    std::string text;
+};
+
+enum class DomainErrorCode : std::uint8_t {
+    InvalidRequest,
+    UnsupportedFeature,
+    ModelNotFound,
+    CapabilityUnavailable,
+    AdmissionRejected,
+    ContextLengthExceeded,
+    Cancelled,
+    DeadlineExceeded,
+    RuntimeFailure,
+};
+
+struct DomainError {
+    DomainErrorCode code{DomainErrorCode::RuntimeFailure};
+    std::string message;
+    std::string parameter;
+    bool retryable{false};
+};
+
+struct ErrorOutput {
+    DomainError error;
+};
+
+using OutputEvent = std::variant<TextOutput, ReasoningOutput,
+                                 ToolCallDeltaOutput, ToolCallOutput,
+                                 UsageOutput, FinishOutput, RefusalOutput,
+                                 ErrorOutput>;
+
+struct GenerationResult {
+    std::string text;
+    std::string reasoning_text;
+    std::string finish_reason{"stop"};
+    int prompt_tokens{0};
+    int cached_prompt_tokens{0};
+    int completion_tokens{0};
+    float duration_ms{0.0f};
+    float generation_duration_ms{0.0f};
+    float prompt_duration_ms{0.0f};
+    float tokens_per_second{0.0f};
+    int mtp_drafted_tokens{0};
+    int mtp_accepted_tokens{0};
+    std::vector<ToolCall> tool_calls;
+};
+
+using RequestOutcome = std::variant<GenerationResult, DomainError>;
+
+enum class Capability : std::uint8_t {
+    TextInput,
+    ImageInput,
+    AudioInput,
+    TextOutput,
+    ReasoningOutput,
+    FunctionTools,
+    StructuredOutput,
+    Embeddings,
+    ImageGeneration,
+    Speech,
+    Transcription,
+};
+
+struct CapabilityDeclaration {
+    Capability capability{Capability::TextInput};
+    bool streaming{false};
+    std::size_t maximum_items{0};
+};
+
+}

--- a/libs/inference/tests/CMakeLists.txt
+++ b/libs/inference/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.27)
+
+add_executable(inference_tests
+    test_domain.cpp
+    test_dependency_policy.cpp
+)
+
+target_link_libraries(inference_tests PRIVATE
+    inference
+    Catch2::Catch2WithMain
+)
+
+target_compile_definitions(inference_tests PRIVATE
+    INFERDECK_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
+set_target_properties(inference_tests PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
+if(MSVC)
+    target_compile_options(inference_tests PRIVATE /W4 /utf-8 /FS)
+else()
+    target_compile_options(inference_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME inference_tests COMMAND inference_tests)
+set_tests_properties(inference_tests PROPERTIES LABELS unit)

--- a/libs/inference/tests/test_dependency_policy.cpp
+++ b/libs/inference/tests/test_dependency_policy.cpp
@@ -1,0 +1,52 @@
+#include <inference/domain.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input), {}};
+}
+
+}
+
+TEST_CASE("model and runtime sources contain no HTTP protocol dependency") {
+    const auto root = std::filesystem::path{INFERDECK_SOURCE_DIR};
+    const std::array directories{
+        root / "libs/inference/include",
+        root / "libs/model/include",
+        root / "libs/model/src",
+        root / "libs/llama_cpp_wrapper/include",
+        root / "libs/llama_cpp_wrapper/src",
+    };
+    const std::array forbidden{
+        "httplib",
+        "gateway/routes",
+        "openai_body_json",
+        "chat.completion",
+        "stream_options",
+    };
+
+    for (const auto& directory : directories) {
+        REQUIRE(std::filesystem::exists(directory));
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(directory)) {
+            if (!entry.is_regular_file()) continue;
+            const auto extension = entry.path().extension();
+            if (extension != ".hpp" && extension != ".cpp") continue;
+            const auto source = read_file(entry.path());
+            for (const auto term : forbidden) {
+                INFO(entry.path().string());
+                INFO(term);
+                CHECK(source.find(term) == std::string::npos);
+            }
+        }
+    }
+}

--- a/libs/inference/tests/test_domain.cpp
+++ b/libs/inference/tests/test_domain.cpp
@@ -1,0 +1,22 @@
+#include <inference/domain.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <type_traits>
+
+using inferdeck::inference::GenerationRequest;
+using inferdeck::inference::RequestOutcome;
+
+static_assert(std::is_default_constructible_v<GenerationRequest>);
+static_assert(std::is_copy_constructible_v<RequestOutcome>);
+
+TEST_CASE() {
+    GenerationRequest request;
+    request.messages.emplace_back(
+        inferdeck::inference::MessageRole::Developer, std::string{});
+    request.tools.emplace_back();
+    CHECK(request.messages.size() == 1);
+    CHECK(request.tools.size() == 1);
+
+    inferdeck::inference::OutputEvent output =
+        inferdeck::inference::UsageOutput{10, 4, 2};
+    CHECK(std::holds_alternative<inferdeck::inference::UsageOutput>(output));
+}

--- a/libs/llama_cpp_wrapper/CMakeLists.txt
+++ b/libs/llama_cpp_wrapper/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 add_library(llama_cpp_wrapper STATIC
     src/llama_cpp_model.cpp
+    src/llama_chat_adapter.cpp
     src/continuous_batch_scheduler.cpp
 )
 

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_chat_adapter.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_chat_adapter.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "chat.h"
+#include "foundation/result.hpp"
+#include "inference/domain.hpp"
+#include "model/model_info.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace inferdeck::llama_wrapper {
+
+struct LlamaChatAdapterOptions {
+    bool supports_thinking{false};
+    bool supports_parallel_tool_calls{false};
+    std::string default_reasoning_format;
+};
+
+struct LlamaChatAdapterResult {
+    common_chat_templates_inputs inputs;
+    std::vector<std::vector<std::uint8_t>> media;
+};
+
+foundation::Result<std::string> apply_reasoning_effort(
+    common_chat_templates_inputs& inputs,
+    const std::optional<std::string>& requested,
+    const model::ModelInfo& info);
+
+foundation::Result<LlamaChatAdapterResult> adapt_generation_request(
+    const inference::GenerationRequest& request,
+    const model::ModelInfo& info,
+    const LlamaChatAdapterOptions& options);
+
+}

--- a/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
+++ b/libs/llama_cpp_wrapper/include/llama_cpp_wrapper/llama_cpp_model.hpp
@@ -9,8 +9,6 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json_fwd.hpp>
-
 #include "chat.h"
 #include "common.h"
 #include "model/imodel.hpp"
@@ -60,11 +58,6 @@ struct LlamaCppConfig {
   std::string reasoning_format{};  // "auto", "deepseek", "deepseek_legacy", "none"
   inferdeck::model::SamplingConfig sampling{};  // server-side sampler defaults (issue #42)
 };
-
-inferdeck::foundation::Result<std::string> apply_reasoning_effort(
-    common_chat_templates_inputs& inputs,
-    const nlohmann::ordered_json& body,
-    const inferdeck::model::ModelInfo& info);
 
 class LlamaCppModel final : public inferdeck::model::IModel,
                             public inferdeck::model::IEmbeddingBackend {

--- a/libs/llama_cpp_wrapper/src/llama_chat_adapter.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_chat_adapter.cpp
@@ -1,0 +1,228 @@
+#include "llama_cpp_wrapper/llama_chat_adapter.hpp"
+
+#include "mtmd-helper.h"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace inferdeck::llama_wrapper {
+
+namespace {
+
+std::string template_role(inference::MessageRole role) {
+    if (role == inference::MessageRole::Developer) return "developer";
+    if (role == inference::MessageRole::System) return "system";
+    if (role == inference::MessageRole::Assistant) return "assistant";
+    if (role == inference::MessageRole::Tool) return "tool";
+    return "user";
+}
+
+common_reasoning_format reasoning_format(inference::ReasoningFormat value) {
+    if (value == inference::ReasoningFormat::None) {
+        return COMMON_REASONING_FORMAT_NONE;
+    }
+    if (value == inference::ReasoningFormat::DeepSeek) {
+        return COMMON_REASONING_FORMAT_DEEPSEEK;
+    }
+    if (value == inference::ReasoningFormat::DeepSeekLegacy) {
+        return COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY;
+    }
+    return COMMON_REASONING_FORMAT_AUTO;
+}
+
+common_reasoning_format reasoning_format(const std::string& value) {
+    if (value == "none") return COMMON_REASONING_FORMAT_NONE;
+    if (value == "deepseek") return COMMON_REASONING_FORMAT_DEEPSEEK;
+    if (value == "deepseek_legacy" || value == "deepseek-legacy") {
+        return COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY;
+    }
+    return COMMON_REASONING_FORMAT_AUTO;
+}
+
+common_chat_tool_choice tool_choice(const inference::ToolChoice& value) {
+    if (value.kind == inference::ToolChoiceKind::None) {
+        return COMMON_CHAT_TOOL_CHOICE_NONE;
+    }
+    if (value.kind == inference::ToolChoiceKind::Required ||
+        value.kind == inference::ToolChoiceKind::Function) {
+        return COMMON_CHAT_TOOL_CHOICE_REQUIRED;
+    }
+    return COMMON_CHAT_TOOL_CHOICE_AUTO;
+}
+
+std::string quote_json_string(const std::string& value) {
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string output{"\""};
+    for (const unsigned char character : value) {
+        if (character == '"' || character == '\\') {
+            output.push_back('\\');
+            output.push_back(static_cast<char>(character));
+        } else if (character < 0x20) {
+            output += "\\u00";
+            output.push_back(hex[(character >> 4) & 0xf]);
+            output.push_back(hex[character & 0xf]);
+        } else {
+            output.push_back(static_cast<char>(character));
+        }
+    }
+    output.push_back('"');
+    return output;
+}
+
+foundation::Result<common_chat_msg> adapt_message(
+    const inference::Message& message,
+    std::vector<std::vector<std::uint8_t>>& media) {
+    common_chat_msg output;
+    output.role = template_role(message.role);
+    output.reasoning_content = message.reasoning;
+    output.tool_call_id = message.tool_call_id;
+    output.tool_name = message.name;
+    for (const auto& call : message.tool_calls) {
+        common_chat_tool_call tool_call;
+        tool_call.id = call.id;
+        tool_call.name = call.name;
+        tool_call.arguments = call.arguments;
+        output.tool_calls.push_back(std::move(tool_call));
+    }
+    for (const auto& part : message.content) {
+        common_chat_msg_content_part content;
+        if (const auto* text = std::get_if<inference::TextContent>(&part)) {
+            content.type = "text";
+            content.text = text->text;
+        } else if (const auto* image =
+                       std::get_if<inference::ImageContent>(&part)) {
+            if (image->bytes.empty()) {
+                return foundation::Err<common_chat_msg>(
+                    foundation::ErrorCode::InvalidArgument,
+                    "image content must not be empty");
+            }
+            std::vector<std::uint8_t> bytes;
+            bytes.reserve(image->bytes.size());
+            for (const auto byte : image->bytes) {
+                bytes.push_back(std::to_integer<std::uint8_t>(byte));
+            }
+            media.push_back(std::move(bytes));
+            content.type = "media_marker";
+            content.text = mtmd_default_marker();
+        } else {
+            return foundation::Err<common_chat_msg>(
+                foundation::ErrorCode::InvalidArgument,
+                "llama text generation does not support audio content");
+        }
+        output.content_parts.push_back(std::move(content));
+    }
+    return foundation::Ok(std::move(output));
+}
+
+}
+
+foundation::Result<std::string> apply_reasoning_effort(
+    common_chat_templates_inputs& inputs,
+    const std::optional<std::string>& requested_value,
+    const model::ModelInfo& info) {
+    std::optional<std::string> requested = requested_value;
+    if (!requested && info.reasoning.supported &&
+        !info.reasoning.default_effort.empty()) {
+        requested = info.reasoning.default_effort;
+    }
+    if (!requested) return foundation::Ok(std::string{});
+    if (!info.reasoning.supported) {
+        return foundation::Err<std::string>(
+            foundation::ErrorCode::InvalidArgument,
+            "model does not support reasoning effort: " + info.name);
+    }
+    std::string resolved = *requested;
+    if (const auto alias = info.reasoning.aliases.find(resolved);
+        alias != info.reasoning.aliases.end()) {
+        resolved = alias->second;
+    }
+    if (resolved == "none") {
+        if (!info.reasoning.none_disables) {
+            return foundation::Err<std::string>(
+                foundation::ErrorCode::InvalidArgument,
+                "reasoning effort 'none' is not supported by model: " +
+                    info.name);
+        }
+        inputs.enable_thinking = false;
+        inputs.chat_template_kwargs.erase("reasoning_effort");
+    } else {
+        if (std::find(info.reasoning.efforts.begin(), info.reasoning.efforts.end(),
+                      resolved) == info.reasoning.efforts.end()) {
+            return foundation::Err<std::string>(
+                foundation::ErrorCode::InvalidArgument,
+                "unsupported reasoning effort '" + *requested +
+                    "' for model: " + info.name);
+        }
+        inputs.chat_template_kwargs["reasoning_effort"] =
+            quote_json_string(resolved);
+    }
+    return foundation::Ok(std::move(resolved));
+}
+
+foundation::Result<LlamaChatAdapterResult> adapt_generation_request(
+    const inference::GenerationRequest& request,
+    const model::ModelInfo& info,
+    const LlamaChatAdapterOptions& options) {
+    LlamaChatAdapterResult result;
+    auto& inputs = result.inputs;
+    inputs.reasoning_format = reasoning_format(options.default_reasoning_format);
+    if (request.reasoning_format != inference::ReasoningFormat::Automatic) {
+        inputs.reasoning_format = reasoning_format(request.reasoning_format);
+    }
+    inputs.add_generation_prompt = request.add_generation_prompt;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = options.supports_thinking;
+    if (request.enable_reasoning) inputs.enable_thinking = *request.enable_reasoning;
+    inputs.parallel_tool_calls = options.supports_parallel_tool_calls &&
+        request.parallel_tool_calls;
+    for (const auto& message : request.messages) {
+        auto adapted = adapt_message(message, result.media);
+        if (!adapted) {
+            return foundation::Err<LlamaChatAdapterResult>(
+                adapted.error().code, adapted.error().message);
+        }
+        inputs.messages.push_back(std::move(*adapted));
+    }
+    if (inputs.messages.empty()) {
+        common_chat_msg message;
+        message.role = "user";
+        message.content = request.prompt;
+        inputs.messages.push_back(std::move(message));
+    }
+    for (const auto& function : request.tools) {
+        if (request.tool_choice.kind == inference::ToolChoiceKind::Function &&
+            function.name != request.tool_choice.function_name) {
+            continue;
+        }
+        common_chat_tool tool;
+        tool.name = function.name;
+        tool.description = function.description;
+        tool.parameters = function.parameters_schema;
+        inputs.tools.push_back(std::move(tool));
+    }
+    inputs.tool_choice = tool_choice(request.tool_choice);
+    if (!inputs.tools.empty() &&
+        inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE &&
+        request.output.kind == inference::StructuredOutputKind::Grammar) {
+        return foundation::Err<LlamaChatAdapterResult>(
+            foundation::ErrorCode::InvalidArgument,
+            "custom grammar constraints cannot be combined with tools");
+    }
+    auto effort = apply_reasoning_effort(inputs, request.reasoning_effort, info);
+    if (!effort) {
+        return foundation::Err<LlamaChatAdapterResult>(
+            effort.error().code, effort.error().message);
+    }
+    if (request.output.kind == inference::StructuredOutputKind::Grammar) {
+        inputs.grammar = request.output.schema;
+    } else if (request.output.kind ==
+                   inference::StructuredOutputKind::JsonObject ||
+               request.output.kind ==
+                   inference::StructuredOutputKind::JsonSchema) {
+        inputs.json_schema = request.output.schema.empty()
+            ? "{}" : request.output.schema;
+    }
+    return foundation::Ok(std::move(result));
+}
+
+}

--- a/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/src/llama_cpp_model.cpp
@@ -1,4 +1,5 @@
 #include "llama_cpp_wrapper/llama_cpp_model.hpp"
+#include "llama_cpp_wrapper/llama_chat_adapter.hpp"
 #include "llama_cpp_wrapper/streaming_tool_call_state.hpp"
 #include "llama_cpp_wrapper/continuous_batch_scheduler.hpp"
 
@@ -326,161 +327,6 @@ std::string normalize_path(const std::string& p) {
   return p;
 }
 
-template <typename Json>
-std::vector<std::vector<uint8_t>> extract_image_media(Json& messages) {
-  std::vector<std::vector<uint8_t>> media;
-  for (auto& message : messages) {
-    if (!message.is_object() || !message.contains("content") ||
-        !message["content"].is_array()) {
-      continue;
-    }
-    for (auto& part : message["content"]) {
-      if (!part.is_object()) continue;
-      const auto type = part.value("type", std::string{});
-      if (type != "image_url" && type != "image" && type != "input_image") {
-        continue;
-      }
-      if (!part.contains("image_url")) {
-        throw std::invalid_argument("image input requires image_url");
-      }
-      const auto& value = part["image_url"];
-      std::string url;
-      if (value.is_string()) {
-        url = value.template get<std::string>();
-      } else if (value.is_object() && value.contains("url") && value["url"].is_string()) {
-        url = value["url"].template get<std::string>();
-      } else {
-        throw std::invalid_argument("image_url must be a string or an object with a string url");
-      }
-      const auto comma = url.find(',');
-      if (comma == std::string::npos ||
-          !url.starts_with("data:image/") ||
-          url.substr(0, comma).find(";base64") == std::string::npos) {
-        throw std::invalid_argument("image_url must be a base64 data:image URL");
-      }
-      const auto encoded = url.substr(comma + 1);
-      if (encoded.empty() || encoded.size() > 32U * 1024U * 1024U) {
-        throw std::invalid_argument("image payload is empty or exceeds 32 MiB encoded");
-      }
-      const auto decoded = base64::decode(encoded);
-      if (decoded.empty()) {
-        throw std::invalid_argument("image payload decoded to empty data");
-      }
-      media.emplace_back(decoded.begin(), decoded.end());
-      part = Json{
-          {"type", "media_marker"},
-          {"text", mtmd_default_marker()},
-      };
-    }
-  }
-  return media;
-}
-
-std::string role_to_template_role(const std::string& role) {
-  if (role == "system") return "system";
-  if (role == "assistant") return "assistant";
-  if (role == "tool") return "tool";
-  return "user";
-}
-
-common_chat_msg to_common_chat_msg(const ChatMessage& msg) {
-  common_chat_msg cmsg;
-  cmsg.role = role_to_template_role(msg.role).c_str();
-  cmsg.content = msg.content.c_str();
-  cmsg.tool_call_id = msg.tool_call_id.c_str();
-
-  if (msg.role == "assistant" && !msg.content.empty()) {
-    try {
-      auto calls = nlohmann::json::parse(msg.content);
-      if (calls.is_array()) {
-        for (const auto& call : calls) {
-          common_chat_tool_call tc;
-          if (call.contains("function")) {
-            const auto& fn = call["function"];
-            tc.name = fn.value("name", "").c_str();
-            if (fn.contains("arguments")) {
-              const auto& a = fn["arguments"];
-              tc.arguments = a.is_string() ? a.get<std::string>().c_str() : a.dump().c_str();
-            }
-          } else if (call.contains("name")) {
-            tc.name = call.value("name", "").c_str();
-            if (call.contains("arguments")) {
-              const auto& a = call["arguments"];
-              tc.arguments = a.is_string() ? a.get<std::string>().c_str() : a.dump().c_str();
-            }
-          }
-          tc.id = call.value("id", "").c_str();
-          if (!tc.name.empty()) cmsg.tool_calls.push_back(std::move(tc));
-        }
-      }
-    } catch (...) {}
-  }
-
-  if (msg.role == "tool") {
-    cmsg.content = msg.content.c_str();
-    cmsg.tool_call_id = msg.tool_call_id.c_str();
-  }
-
-  return cmsg;
-}
-
-std::vector<common_chat_tool> parse_tools_json(const std::string& tools_json) {
-  std::vector<common_chat_tool> tools;
-  if (tools_json.empty()) return tools;
-  try {
-    auto j = nlohmann::json::parse(tools_json);
-    if (!j.is_array()) return tools;
-    for (const auto& item : j) {
-      common_chat_tool tool;
-      if (item.contains("function")) {
-        const auto& fn = item["function"];
-        tool.name = fn.value("name", "").c_str();
-        tool.description = fn.value("description", "").c_str();
-        if (fn.contains("parameters")) {
-          tool.parameters = fn["parameters"].dump().c_str();
-        }
-      } else {
-        tool.name = item.value("name", "").c_str();
-        tool.description = item.value("description", "").c_str();
-        if (item.contains("parameters")) {
-          tool.parameters = item["parameters"].dump().c_str();
-        }
-      }
-      if (!tool.name.empty()) tools.push_back(std::move(tool));
-    }
-  } catch (...) {}
-  return tools;
-}
-
-common_reasoning_format parse_reasoning_format(const std::string& value) {
-  if (value.empty()) return COMMON_REASONING_FORMAT_AUTO;
-  std::string lower = value;
-  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-  std::replace(lower.begin(), lower.end(), '-', '_');
-  if (lower == "none") return COMMON_REASONING_FORMAT_NONE;
-  if (lower == "deepseek") return COMMON_REASONING_FORMAT_DEEPSEEK;
-  if (lower == "deepseek_legacy") return COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY;
-  if (lower == "auto") return COMMON_REASONING_FORMAT_AUTO;
-  return COMMON_REASONING_FORMAT_AUTO;
-}
-
-common_chat_tool_choice parse_tool_choice(const nlohmann::ordered_json& body) {
-  if (!body.contains("tool_choice") || body["tool_choice"].is_null()) {
-    return COMMON_CHAT_TOOL_CHOICE_AUTO;
-  }
-  const auto& tc = body["tool_choice"];
-  if (tc.is_string()) {
-    return common_chat_tool_choice_parse_oaicompat(tc.get<std::string>());
-  }
-  if (tc.is_object()) {
-    const auto type = tc.value("type", std::string{"auto"});
-    if (type == "none") return COMMON_CHAT_TOOL_CHOICE_NONE;
-    if (type == "required" || type == "any") return COMMON_CHAT_TOOL_CHOICE_REQUIRED;
-    return COMMON_CHAT_TOOL_CHOICE_AUTO;
-  }
-  return COMMON_CHAT_TOOL_CHOICE_AUTO;
-}
-
 std::vector<llama_token> tokenize_stop_strings(
     const llama_vocab* vocab, const std::vector<std::string>& stops) {
   std::vector<llama_token> tokens;
@@ -516,18 +362,6 @@ std::string token_to_piece(const llama_vocab* vocab, llama_token token) {
     if (required <= buffer.size()) return {};
     buffer.resize(required);
   }
-}
-
-std::string tool_call_json(const common_chat_tool_call& tc) {
-  nlohmann::json j = {
-      {"type", "function"},
-      {"function", {
-          {"name", tc.name},
-          {"arguments", tc.arguments},
-      }},
-  };
-  if (!tc.id.empty()) j["id"] = tc.id;
-  return j.dump();
 }
 
 ToolCall to_tool_call(const common_chat_tool_call& tc) {
@@ -722,10 +556,8 @@ void apply_parsed_message(InferenceResult& out, const common_chat_msg& msg) {
   out.text = msg.content;
   out.reasoning_text = msg.reasoning_content;
   out.tool_calls.clear();
-  out.tool_calls_json.clear();
   for (const auto& tc : msg.tool_calls) {
     out.tool_calls.push_back(to_tool_call(tc));
-    out.tool_calls_json.push_back(tool_call_json(tc));
   }
 }
 
@@ -743,18 +575,6 @@ void apply_fallback_tool_calls(InferenceResult& out, const std::string& generate
   if (!calls || calls->empty()) return;
   out.text.clear();
   out.tool_calls = std::move(*calls);
-  out.tool_calls_json.clear();
-  for (const auto& tc : out.tool_calls) {
-    nlohmann::json j = {
-        {"type", "function"},
-        {"function", {
-            {"name", tc.function_name},
-            {"arguments", tc.function_arguments},
-        }},
-    };
-    if (!tc.id.empty()) j["id"] = tc.id;
-    out.tool_calls_json.push_back(j.dump());
-  }
 }
 
 bool fallback_tool_call_complete(const std::string& generated) {
@@ -762,66 +582,6 @@ bool fallback_tool_call_complete(const std::string& generated) {
 }
 
 } // namespace
-
-foundation::Result<std::string> apply_reasoning_effort(
-    common_chat_templates_inputs& inputs,
-    const nlohmann::ordered_json& body,
-    const model::ModelInfo& info) {
-  std::optional<std::string> requested;
-  if (body.contains("chat_template_kwargs") &&
-      body["chat_template_kwargs"].is_object() &&
-      body["chat_template_kwargs"].contains("reasoning_effort")) {
-    if (!body["chat_template_kwargs"]["reasoning_effort"].is_string()) {
-      return foundation::Err<std::string>(
-          foundation::ErrorCode::InvalidArgument,
-          "chat_template_kwargs.reasoning_effort must be a string");
-    }
-    requested =
-        body["chat_template_kwargs"]["reasoning_effort"].get<std::string>();
-  } else if (body.contains("reasoning_effort")) {
-    if (!body["reasoning_effort"].is_string()) {
-      return foundation::Err<std::string>(
-          foundation::ErrorCode::InvalidArgument,
-          "reasoning_effort must be a string");
-    }
-    requested = body["reasoning_effort"].get<std::string>();
-  } else if (info.reasoning.supported &&
-             !info.reasoning.default_effort.empty()) {
-    requested = info.reasoning.default_effort;
-  }
-  if (!requested) return foundation::Ok(std::string{});
-  if (!info.reasoning.supported) {
-    return foundation::Err<std::string>(
-        foundation::ErrorCode::InvalidArgument,
-        "model does not support reasoning effort: " + info.name);
-  }
-
-  std::string resolved = *requested;
-  if (const auto alias = info.reasoning.aliases.find(resolved);
-      alias != info.reasoning.aliases.end()) {
-    resolved = alias->second;
-  }
-  if (resolved == "none") {
-    if (!info.reasoning.none_disables) {
-      return foundation::Err<std::string>(
-          foundation::ErrorCode::InvalidArgument,
-          "reasoning effort 'none' is not supported by model: " + info.name);
-    }
-    inputs.enable_thinking = false;
-    inputs.chat_template_kwargs.erase("reasoning_effort");
-  } else {
-    if (std::find(info.reasoning.efforts.begin(), info.reasoning.efforts.end(),
-                  resolved) == info.reasoning.efforts.end()) {
-      return foundation::Err<std::string>(
-          foundation::ErrorCode::InvalidArgument,
-          "unsupported reasoning effort '" + *requested + "' for model: " +
-              info.name);
-    }
-    inputs.chat_template_kwargs["reasoning_effort"] =
-        nlohmann::json(resolved).dump();
-  }
-  return foundation::Ok(std::move(resolved));
-}
 
 std::string LlamaCppModel::version() {
   const char* info = llama_print_system_info();
@@ -1375,69 +1135,27 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
     return Result<ChatTemplateResult>(std::unexpect, make_error(ErrorCode::Internal, "chat templates not initialized"));
   }
 
-  common_chat_templates_inputs inputs;
-  nlohmann::ordered_json body = nlohmann::ordered_json::object();
-  if (!req.openai_body_json.empty()) {
-    try {
-      body = nlohmann::ordered_json::parse(req.openai_body_json);
-    } catch (const std::exception& e) {
-      return Result<ChatTemplateResult>(std::unexpect,
-          make_error(ErrorCode::ParseError, std::string("invalid OpenAI request JSON: ") + e.what()));
-    }
-  }
-  std::vector<std::vector<uint8_t>> media;
-  if (body.contains("messages") && body["messages"].is_array()) {
-    try {
-      media = extract_image_media(body["messages"]);
-    } catch (const std::exception& e) {
-      return Result<ChatTemplateResult>(std::unexpect,
-          make_error(ErrorCode::InvalidArgument, e.what()));
-    }
-    if (!media.empty() && mtmd_ == nullptr) {
-      return Result<ChatTemplateResult>(std::unexpect,
-          make_error(ErrorCode::InvalidArgument,
-                     "image input requires a loaded vision projector"));
-    }
-  }
-
-  inputs.reasoning_format = parse_reasoning_format(info_.reasoning_format.empty() ? cfg_.reasoning_format : info_.reasoning_format);
-  if (body.contains("reasoning_format") && body["reasoning_format"].is_string()) {
-    inputs.reasoning_format = parse_reasoning_format(body["reasoning_format"].get<std::string>());
-  }
-  inputs.add_generation_prompt = true;
-  if (body.contains("add_generation_prompt") && body["add_generation_prompt"].is_boolean()) {
-    inputs.add_generation_prompt = body["add_generation_prompt"].get<bool>();
-  }
-  inputs.use_jinja = true;
-  inputs.enable_thinking = common_chat_templates_support_enable_thinking(chat_templates_);
   auto caps = common_chat_templates_get_caps(chat_templates_);
-  inputs.parallel_tool_calls = caps["supports_parallel_tool_calls"];
-
-  if (body.contains("messages") && body["messages"].is_array()) {
-    for (auto& m : body["messages"]) {
-      if (m.is_object() && !m.contains("content") && !m.contains("tool_calls")) {
-        m["content"] = "";
-      }
-    }
-    try {
-      inputs.messages = common_chat_msgs_parse_oaicompat(body["messages"]);
-    } catch (const std::exception& e) {
-      return Result<ChatTemplateResult>(std::unexpect,
-          make_error(ErrorCode::ParseError, std::string("invalid OpenAI messages: ") + e.what()));
-    }
-  } else {
-    for (const auto& m : req.messages) {
-      inputs.messages.push_back(to_common_chat_msg(m));
-    }
-    if (inputs.messages.empty()) {
-      common_chat_msg msg;
-      msg.role = "user";
-      msg.content = req.prompt;
-      inputs.messages.push_back(std::move(msg));
-    }
+  LlamaChatAdapterOptions adapter_options;
+  adapter_options.supports_thinking =
+      common_chat_templates_support_enable_thinking(chat_templates_);
+  adapter_options.supports_parallel_tool_calls =
+      caps["supports_parallel_tool_calls"];
+  adapter_options.default_reasoning_format = info_.reasoning_format.empty()
+      ? cfg_.reasoning_format : info_.reasoning_format;
+  auto adapted = adapt_generation_request(req, info_, adapter_options);
+  if (!adapted) {
+    return Result<ChatTemplateResult>(std::unexpect,
+        make_error(adapted.error().code, adapted.error().message));
+  }
+  auto inputs = std::move(adapted->inputs);
+  auto media = std::move(adapted->media);
+  if (!media.empty() && mtmd_ == nullptr) {
+    return Result<ChatTemplateResult>(std::unexpect,
+        make_error(ErrorCode::InvalidArgument,
+                   "image input requires a loaded vision projector"));
   }
 
-  // DEBUG: log incoming request shape so we can compare OpenCode vs direct Ollama.
   {
     std::size_t sys_chars = 0, user_chars = 0, tool_result_chars = 0;
     int n_sys = 0, n_user = 0, n_assistant = 0, n_tool = 0;
@@ -1448,75 +1166,17 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
       else if (m.role == "assistant") { ++n_assistant; }
       else if (m.role == "tool") { ++n_tool; tool_result_chars += len; }
     }
-    const int n_tools_defined = body.contains("tools") && body["tools"].is_array()
-                                  ? static_cast<int>(body["tools"].size()) : 0;
-    const int max_tok = body.value(
-        "max_tokens", inferdeck::model::k_max_tokens_use_context_budget);
     LOG_INFO("request_shape",
              "model={} msgs={} [sys={} sys_chars={} user={} asst={} tool_results={} tool_result_chars={}] "
              "tools_defined={} max_tokens={}",
              info_.name, inputs.messages.size(),
              n_sys, sys_chars, n_user, n_assistant, n_tool, tool_result_chars,
-             n_tools_defined, max_tok);
+             req.tools.size(), req.max_output_tokens);
   }
 
-  if (body.contains("tools") && body["tools"].is_array()) {
-    try {
-      inputs.tools = common_chat_tools_parse_oaicompat(body["tools"]);
-    } catch (const std::exception& e) {
-      return Result<ChatTemplateResult>(std::unexpect,
-          make_error(ErrorCode::ParseError, std::string("invalid OpenAI tools: ") + e.what()));
-    }
-    inputs.tool_choice = parse_tool_choice(body);
-  } else if (!req.tools_json.empty()) {
-    inputs.tools = parse_tools_json(req.tools_json);
-    inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
-  }
-  if (!inputs.tools.empty() && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE &&
-      body.contains("grammar")) {
-    return Result<ChatTemplateResult>(std::unexpect,
-        make_error(ErrorCode::InvalidArgument, "Cannot use custom grammar constraints with tools."));
-  }
-  if (body.contains("parallel_tool_calls") && body["parallel_tool_calls"].is_boolean()) {
-    inputs.parallel_tool_calls = body["parallel_tool_calls"].get<bool>();
-  }
-  if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object()) {
-    for (const auto& item : body["chat_template_kwargs"].items()) {
-      inputs.chat_template_kwargs[item.key()] = item.value().dump();
-    }
-    const auto it = inputs.chat_template_kwargs.find("enable_thinking");
-    if (it != inputs.chat_template_kwargs.end()) {
-      if (it->second == "true") inputs.enable_thinking = true;
-      if (it->second == "false") inputs.enable_thinking = false;
-    }
-  }
-  auto reasoning_effort = apply_reasoning_effort(inputs, body, info_);
-  if (!reasoning_effort) {
-    return Result<ChatTemplateResult>(std::unexpect,
-        make_error(reasoning_effort.error().code, reasoning_effort.error().message));
-  }
-  if (!reasoning_effort->empty()) {
+  if (req.reasoning_effort) {
     LOG_INFO("reasoning_effort_applied", "model={} effort={}",
-             info_.name, *reasoning_effort);
-  }
-  if (body.contains("grammar") && body["grammar"].is_string()) {
-    inputs.grammar = body["grammar"].get<std::string>();
-  }
-  if (body.contains("json_schema")) {
-    inputs.json_schema = body["json_schema"].is_null() ? "" : body["json_schema"].dump();
-  }
-  if (body.contains("response_format") && body["response_format"].is_object()) {
-    const auto& rf = body["response_format"];
-    const auto type = rf.value("type", std::string{});
-    if (type == "json_object") {
-      if (rf.contains("schema")) inputs.json_schema = rf["schema"].dump();
-      else if (inputs.json_schema.empty()) inputs.json_schema = nlohmann::ordered_json::object().dump();
-    } else if (type == "json_schema" && rf.contains("json_schema")) {
-      const auto& wrapper = rf["json_schema"];
-      if (wrapper.is_object() && wrapper.contains("schema")) {
-        inputs.json_schema = wrapper["schema"].dump();
-      }
-    }
+             info_.name, *req.reasoning_effort);
   }
 
   try {
@@ -1575,31 +1235,25 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
   if (!chat_params.parser.empty()) {
     result.parser_params.parser.load(chat_params.parser);
   }
-  if (body.contains("stop")) {
-    if (body["stop"].is_string()) {
-      result.stop_strings.push_back(body["stop"].get<std::string>());
-    } else if (body["stop"].is_array()) {
-      for (const auto& stop : body["stop"]) {
-        if (stop.is_string()) result.stop_strings.push_back(stop.get<std::string>());
-      }
-    }
-  }
-  // Sampler params: explicit per-request (OpenAI body) values win; otherwise
+  result.stop_strings.insert(result.stop_strings.end(), req.stop.begin(),
+                             req.stop.end());
+  // Sampler params: explicit per-request values win; otherwise
   // fall back to the server-side SamplingConfig defaults (issue #42), which
   // mirror stock llama-server (DRY off, repeat_penalty neutral).
   const auto& sc = cfg_.sampling;
-  result.sampling_params.temp          = req.temperature.value_or(sc.temperature);
-  result.sampling_params.top_p         = req.top_p.value_or(sc.top_p);
-  result.sampling_params.top_k         = req.top_k.value_or(sc.top_k);
-  result.sampling_params.min_p         = sc.min_p;
-  result.sampling_params.penalty_repeat = req.repeat_penalty.value_or(sc.repeat_penalty);
-  result.sampling_params.penalty_last_n = req.repeat_last_n.value_or(sc.repeat_last_n);
+  result.sampling_params.temp          = req.sampling.temperature.value_or(sc.temperature);
+  result.sampling_params.top_p         = req.sampling.top_p.value_or(sc.top_p);
+  result.sampling_params.top_k         = req.sampling.top_k.value_or(sc.top_k);
+  result.sampling_params.min_p         = req.sampling.min_p.value_or(sc.min_p);
+  result.sampling_params.penalty_repeat = req.sampling.repeat_penalty.value_or(sc.repeat_penalty);
+  result.sampling_params.penalty_last_n = req.sampling.repeat_last_n.value_or(sc.repeat_last_n);
   result.sampling_params.dry_multiplier     = sc.dry_multiplier;
   result.sampling_params.dry_base           = sc.dry_base;
   result.sampling_params.dry_allowed_length = sc.dry_allowed_length;
   result.sampling_params.dry_penalty_last_n = sc.dry_penalty_last_n;
   result.sampling_params.dry_sequence_breakers = sc.dry_seq_breakers;
-  result.sampling_params.seed = req.seed >= 0 ? static_cast<std::uint32_t>(req.seed) : LLAMA_DEFAULT_SEED;
+  result.sampling_params.seed = req.sampling.seed >= 0
+      ? static_cast<std::uint32_t>(req.sampling.seed) : LLAMA_DEFAULT_SEED;
 
   // DEBUG (issue #42 diagnosis): log what the client sent vs what was resolved,
   // so we can see whether OpenCode/Claude Code override the server-side config.
@@ -1613,8 +1267,9 @@ Result<ChatTemplateResult> LlamaCppModel::apply_chat_template(
            "model={} client[temp={} top_p={} top_k={} repeat_penalty={} repeat_last_n={}] "
            "resolved[temp={:.3f} top_p={:.3f} top_k={} min_p={:.3f} repeat_penalty={:.3f} "
            "repeat_last_n={} dry_mult={:.3f}]",
-           info_.name, opt_f(req.temperature), opt_f(req.top_p), opt_i(req.top_k),
-           opt_f(req.repeat_penalty), opt_i(req.repeat_last_n),
+           info_.name, opt_f(req.sampling.temperature), opt_f(req.sampling.top_p),
+           opt_i(req.sampling.top_k), opt_f(req.sampling.repeat_penalty),
+           opt_i(req.sampling.repeat_last_n),
            result.sampling_params.temp, result.sampling_params.top_p,
            result.sampling_params.top_k, result.sampling_params.min_p,
            result.sampling_params.penalty_repeat, result.sampling_params.penalty_last_n,
@@ -1662,7 +1317,7 @@ Result<LlamaCppModel::PredictSetup> LlamaCppModel::prepare_inference(
     // See maybe_truncate_prompt: clamp bounds must satisfy lo <= hi (UB
     // otherwise) when n_ctx_seq < 1024.
     const int reserve_hi = n_ctx_seq / 4;
-    const int reserve = std::clamp(req.max_tokens > 0 ? req.max_tokens : 1024,
+    const int reserve = std::clamp(req.max_output_tokens > 0 ? req.max_output_tokens : 1024,
                                    std::min(256, reserve_hi), reserve_hi);
     budget = n_ctx_seq - reserve - 1;
   }
@@ -1840,14 +1495,15 @@ Result<LlamaCppModel::PredictSetup> LlamaCppModel::prepare_inference(
                      "This model's maximum context length is " + std::to_string(s.n_ctx_seq) +
                      " tokens. However, your messages resulted in " + std::to_string(prompt_context) +
                      " tokens. Please reduce the length of the messages."));
-    maybe_truncate_prompt(s.prompt_tokens, s.n_ctx_seq, req.max_tokens, info_.name);
+    maybe_truncate_prompt(s.prompt_tokens, s.n_ctx_seq, req.max_output_tokens, info_.name);
     n_tokens = static_cast<int>(s.prompt_tokens.size());
     s.prompt_position_count = n_tokens;
   }
 
   const int ctx_budget = std::max(
       1, s.n_ctx_seq - s.prompt_position_count - 1);
-  s.max_tokens = req.max_tokens > 0 ? std::min(req.max_tokens, ctx_budget) : ctx_budget;
+  s.max_tokens = req.max_output_tokens > 0
+      ? std::min(req.max_output_tokens, ctx_budget) : ctx_budget;
 
   // Snapshot per-slot KV state under the mutex (scheduler may touch these after submit)
   {

--- a/libs/llama_cpp_wrapper/tests/test_llama_cpp_model.cpp
+++ b/libs/llama_cpp_wrapper/tests/test_llama_cpp_model.cpp
@@ -1,6 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <nlohmann/json.hpp>
-
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -12,6 +10,7 @@
 #include <vector>
 
 #include "llama_cpp_wrapper/llama_cpp_model.hpp"
+#include "llama_cpp_wrapper/llama_chat_adapter.hpp"
 #include "llama_cpp_wrapper/streaming_tool_call_state.hpp"
 #include "foundation/logging.hpp"
 #include "model/imodel.hpp"
@@ -47,18 +46,14 @@ TEST_CASE("LlamaCppModel: reasoning effort reaches chat template inputs",
   info.reasoning.aliases = {{"high", "xhigh"}};
 
   common_chat_templates_inputs inputs;
-  nlohmann::ordered_json body = {
-      {"reasoning_effort", "medium"},
-      {"chat_template_kwargs", {{"reasoning_effort", "low"}}},
-  };
-  auto effort = apply_reasoning_effort(inputs, body, info);
+  auto effort = apply_reasoning_effort(inputs, std::string{"low"}, info);
   REQUIRE(effort);
   CHECK(*effort == "low");
   CHECK(inputs.chat_template_kwargs.at("reasoning_effort") == "\"low\"");
 
   common_chat_templates_inputs alias_inputs;
   effort = apply_reasoning_effort(
-      alias_inputs, nlohmann::ordered_json{{"reasoning_effort", "high"}}, info);
+      alias_inputs, std::string{"high"}, info);
   REQUIRE(effort);
   CHECK(*effort == "xhigh");
   CHECK(alias_inputs.chat_template_kwargs.at("reasoning_effort") == "\"xhigh\"");
@@ -66,7 +61,7 @@ TEST_CASE("LlamaCppModel: reasoning effort reaches chat template inputs",
   common_chat_templates_inputs disabled_inputs;
   disabled_inputs.enable_thinking = true;
   effort = apply_reasoning_effort(
-      disabled_inputs, nlohmann::ordered_json{{"reasoning_effort", "none"}}, info);
+      disabled_inputs, std::string{"none"}, info);
   REQUIRE(effort);
   CHECK(*effort == "none");
   CHECK_FALSE(disabled_inputs.enable_thinking);
@@ -79,9 +74,59 @@ TEST_CASE("LlamaCppModel: unsupported reasoning effort is rejected",
   info.name = "plain-model";
   common_chat_templates_inputs inputs;
   auto effort = apply_reasoning_effort(
-      inputs, nlohmann::ordered_json{{"reasoning_effort", "medium"}}, info);
+      inputs, std::string{"medium"}, info);
   REQUIRE_FALSE(effort);
   CHECK(effort.error().code == ErrorCode::InvalidArgument);
+}
+
+TEST_CASE("Llama chat adapter preserves typed roles and tool defaults",
+          "[llama][adapter]") {
+  inference::GenerationRequest request;
+  request.messages.emplace_back(inference::MessageRole::Developer, "policy");
+  request.messages.emplace_back(inference::MessageRole::System, "context");
+  request.messages.emplace_back(inference::MessageRole::User, "question");
+  request.tools.push_back(inference::FunctionTool{.name = "lookup"});
+  request.enable_reasoning = false;
+
+  ModelInfo info;
+  info.name = "typed-model";
+  LlamaChatAdapterOptions options;
+  options.supports_thinking = true;
+  const auto adapted = adapt_generation_request(request, info, options);
+  REQUIRE(adapted);
+  REQUIRE(adapted->inputs.messages.size() == 3);
+  CHECK(adapted->inputs.messages[0].role == "developer");
+  CHECK(adapted->inputs.messages[1].role == "system");
+  CHECK(adapted->inputs.messages[2].role == "user");
+  REQUIRE(adapted->inputs.tools.size() == 1);
+  CHECK(adapted->inputs.tools[0].parameters == "{}");
+  CHECK_FALSE(adapted->inputs.enable_thinking);
+}
+
+TEST_CASE("Llama chat adapter rejects unsupported or empty media",
+          "[llama][adapter][validation]") {
+  ModelInfo info;
+  info.name = "typed-model";
+  LlamaChatAdapterOptions options;
+
+  inference::GenerationRequest audio_request;
+  inference::Message audio_message;
+  audio_message.role = inference::MessageRole::User;
+  audio_message.content.emplace_back(inference::AudioContent{
+      {std::byte{0x01}}, "audio/wav"});
+  audio_request.messages.push_back(std::move(audio_message));
+  const auto audio = adapt_generation_request(audio_request, info, options);
+  REQUIRE_FALSE(audio);
+  CHECK(audio.error().code == ErrorCode::InvalidArgument);
+
+  inference::GenerationRequest image_request;
+  inference::Message image_message;
+  image_message.role = inference::MessageRole::User;
+  image_message.content.emplace_back(inference::ImageContent{});
+  image_request.messages.push_back(std::move(image_message));
+  const auto image = adapt_generation_request(image_request, info, options);
+  REQUIRE_FALSE(image);
+  CHECK(image.error().code == ErrorCode::InvalidArgument);
 }
 
 TEST_CASE("LlamaCppModel: backend init/shutdown do not throw", "[llama][backend]") {
@@ -431,7 +476,7 @@ TEST_CASE("recurrent checkpoint: second predict on same slot reuses cache",
 
   InferenceRequest req;
   req.messages = {ChatMessage{"user", "Say hello."}};
-  req.max_tokens = 4;
+  req.max_output_tokens = 4;
   auto r1 = lm.predict(slot_id, req);
   REQUIRE(r1.has_value());
 
@@ -469,7 +514,7 @@ TEST_CASE("recurrent checkpoint: multi-turn conversation reuses cache on second 
 
   InferenceRequest req1;
   req1.messages = {ChatMessage{"user", "Count to three."}};
-  req1.max_tokens = 8;
+  req1.max_output_tokens = 8;
   auto r1 = lm.predict(slot_id, req1);
   REQUIRE(r1.has_value());
 
@@ -482,7 +527,7 @@ TEST_CASE("recurrent checkpoint: multi-turn conversation reuses cache on second 
       ChatMessage{"assistant", r1->text},
       ChatMessage{"user",      "Now count to five."},
   };
-  req2.max_tokens = 8;
+  req2.max_output_tokens = 8;
   auto r2 = lm.predict(slot_id, req2);
   REQUIRE(r2.has_value());
   REQUIRE(r2->cached_prompt_tokens > 0);
@@ -522,7 +567,7 @@ TEST_CASE("MTP recurrent checkpoint reuses an identical prompt",
 
   InferenceRequest req;
   req.messages = {ChatMessage{"user", "Reply with only CACHE_OK."}};
-  req.max_tokens = 4;
+  req.max_output_tokens = 4;
   auto first = lm.predict(slot_id, req);
   REQUIRE(first.has_value());
   auto second = lm.predict(slot_id, req);
@@ -569,11 +614,11 @@ TEST_CASE("MTP cancellation is safe while another slot decodes",
   InferenceRequest first_request;
   first_request.messages = {
       ChatMessage{"user", "Write a long numbered list without stopping."}};
-  first_request.max_tokens = 1024;
+  first_request.max_output_tokens = 1024;
   InferenceRequest second_request;
   second_request.messages = {
       ChatMessage{"user", "Count from one to twenty, one number per line."}};
-  second_request.max_tokens = 64;
+  second_request.max_output_tokens = 64;
 
   auto first = std::async(std::launch::async, [&] {
     return lm.predict_stream(

--- a/libs/model/CMakeLists.txt
+++ b/libs/model/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(model
 target_link_libraries(model
     PUBLIC
         foundation
+        inference
 )
 
 set_target_properties(model PROPERTIES

--- a/libs/model/include/model/imodel.hpp
+++ b/libs/model/include/model/imodel.hpp
@@ -9,58 +9,20 @@
 #include <vector>
 
 #include "foundation/result.hpp"
+#include "inference/domain.hpp"
 #include "model/ibackend.hpp"
 
 namespace inferdeck::model {
 
-inline constexpr int k_max_tokens_use_context_budget = -1;
+inline constexpr int k_max_tokens_use_context_budget =
+    inference::kUseContextBudget;
 
-struct ChatMessage {
-    std::string role{};
-    std::string content{};
-    std::string tool_call_id{};
-    std::string name{};
-};
+using ChatMessage = inference::Message;
+using ToolCall = inference::ToolCall;
+using ToolCallDelta = inference::ToolCallDelta;
+using InferenceRequest = inference::GenerationRequest;
 
-struct ToolCall {
-    std::string id{};
-    std::string type{"function"};
-    std::string function_name{};
-    std::string function_arguments{};
-};
-
-struct ToolCallDelta {
-    std::size_t index{0};
-    std::string id{};
-    std::string type{};
-    std::string function_name{};
-    std::string function_arguments{};
-};
-
-struct InferenceDelta {
-    std::string content{};
-    std::string reasoning_text{};
-    std::vector<ToolCallDelta> tool_calls{};
-};
-
-struct InferenceRequest {
-    std::string prompt{};
-    std::vector<ChatMessage> messages{};
-    std::string tools_json{};
-    std::string openai_body_json{};
-    int max_tokens{k_max_tokens_use_context_budget};
-    // Sampler params are optional so the server can tell an explicit client
-    // value apart from "unset" (issue #42). When unset, the server-side
-    // SamplingConfig default applies; when set, the client value wins.
-    std::optional<float> temperature{};
-    std::optional<float> top_p{};
-    std::optional<int> top_k{};
-    std::optional<float> repeat_penalty{};
-    std::optional<int> repeat_last_n{};
-    int seed{-1};
-    std::optional<std::string> tool_format{};
-    std::optional<std::string> grammar{};
-};
+using InferenceDelta = inference::GenerationDelta;
 
 struct ChatTemplateMeta {
     std::string thinking_start_tag;
@@ -69,22 +31,7 @@ struct ChatTemplateMeta {
     bool supports_thinking = false;
 };
 
-struct InferenceResult {
-    std::string text{};
-    std::string reasoning_text{};
-    std::string finish_reason{"stop"};
-    int prompt_tokens{0};
-    int cached_prompt_tokens{0};
-    int completion_tokens{0};
-    float duration_ms{0.0f};
-    float generation_duration_ms{0.0f};
-    float prompt_duration_ms{0.0f};
-    float tokens_per_second{0.0f};
-    int mtp_drafted_tokens{0};
-    int mtp_accepted_tokens{0};
-    std::vector<std::string> tool_calls_json{};
-    std::vector<ToolCall> tool_calls{};
-};
+using InferenceResult = inference::GenerationResult;
 
 struct EmbeddingRequest {
     std::vector<std::string> inputs;

--- a/libs/model/tests/test_model.cpp
+++ b/libs/model/tests/test_model.cpp
@@ -916,7 +916,7 @@ TEST_CASE("BackendCoordinator: predict routes to model", "[model][coordinator]")
     REQUIRE(s.has_value());
     InferenceRequest req;
     req.prompt = "hi";
-    req.max_tokens = 8;
+    req.max_output_tokens = 8;
     auto r = c.predict("a", s.value(), req);
     REQUIRE(r.has_value());
     REQUIRE(r.value().text == "hello world");

--- a/overhall_plan.md
+++ b/overhall_plan.md
@@ -341,37 +341,37 @@ current implementation cannot satisfy the native single-process rule.
 
 ### New domain boundary
 
-- [ ] Introduce a focused library for protocol-neutral inference contracts.
-- [ ] Define typed `RequestContext` with request ID, principal, endpoint, deadline,
+- [x] Introduce a focused library for protocol-neutral inference contracts.
+- [x] Define typed `RequestContext` with request ID, principal, endpoint, deadline,
       cancellation, requested model, resolved model, stream mode and compatibility
       profile.
-- [ ] Define typed instructions, messages/input items, text/image/audio content,
+- [x] Define typed instructions, messages/input items, text/image/audio content,
       function tools, tool choice, structured-output constraints and sampling.
-- [ ] Define typed `OutputEvent` variants for text, reasoning, tool calls, usage,
+- [x] Define typed `OutputEvent` variants for text, reasoning, tool calls, usage,
       finish, refusal, and error.
-- [ ] Define canonical `RequestOutcome` and `DomainError` taxonomies.
-- [ ] Define capability declarations independently of HTTP fields.
-- [ ] Remove `openai_body_json` from `InferenceRequest`.
-- [ ] Remove protocol parsing from `LlamaCppModel` and every runtime backend.
-- [ ] Move prompt-template conversion into a typed llama adapter layer.
-- [ ] Prohibit `httplib`, route headers, OpenAI field names, and protocol response
+- [x] Define canonical `RequestOutcome` and `DomainError` taxonomies.
+- [x] Define capability declarations independently of HTTP fields.
+- [x] Remove `openai_body_json` from `InferenceRequest`.
+- [x] Remove protocol parsing from `LlamaCppModel` and every runtime backend.
+- [x] Move prompt-template conversion into a typed llama adapter layer.
+- [x] Prohibit `httplib`, route headers, OpenAI field names, and protocol response
       objects from model and runtime libraries.
 
 ### Generation session
 
-- [ ] Extract one `GenerationSession` service shared by Chat and Responses.
-- [ ] Centralize slot ownership, cancellation, backpressure, inference-thread
+- [x] Extract one `GenerationSession` service shared by Chat and Responses.
+- [x] Centralize slot ownership, cancellation, backpressure, inference-thread
       lifetime, finish-once behavior and request recording.
-- [ ] Preserve bounded queues, UTF-8 holdback, cursor sanitization and idempotent
+- [x] Preserve bounded queues, UTF-8 holdback, cursor sanitization and idempotent
       release semantics.
 
 ### Exit gate
 
-- [ ] Dependency tests prove model/runtime libraries contain no HTTP or protocol
+- [x] Dependency tests prove model/runtime libraries contain no HTTP or protocol
       JSON dependency.
-- [ ] Golden adapter tests convert OpenAI requests to canonical objects and
+- [x] Golden adapter tests convert OpenAI requests to canonical objects and
       canonical events back to wire output.
-- [ ] Chat and Responses share execution lifecycle without calling one another's
+- [x] Chat and Responses share execution lifecycle without calling one another's
       HTTP handlers.
 
 ## Phase 6 - Complete strict OpenAI adapters

--- a/tests/fixtures/openai_adapter_golden.json
+++ b/tests/fixtures/openai_adapter_golden.json
@@ -1,0 +1,58 @@
+{
+  "chat_request": {
+    "messages": [
+      {"role": "developer", "content": "policy"},
+      {"role": "user", "content": "answer"}
+    ],
+    "max_completion_tokens": 64,
+    "temperature": 0.25,
+    "top_p": 0.9,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "lookup",
+          "description": "find",
+          "parameters": {"type": "object"}
+        }
+      }
+    ],
+    "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "answer",
+        "schema": {"type": "object"},
+        "strict": true
+      }
+    }
+  },
+  "canonical": {
+    "roles": ["developer", "user"],
+    "texts": ["policy", "answer"],
+    "max_output_tokens": 64,
+    "temperature": 0.25,
+    "top_p": 0.9,
+    "tool_name": "lookup",
+    "tool_schema": "{\"type\":\"object\"}",
+    "tool_choice": "lookup",
+    "output_kind": "json_schema",
+    "output_name": "answer",
+    "output_strict": true
+  },
+  "responses_event_types": [
+    "response.created",
+    "response.in_progress",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.reasoning_text.delta",
+    "response.output_item.added",
+    "response.function_call_arguments.delta",
+    "response.reasoning_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+    "response.function_call_arguments.done",
+    "response.output_item.done",
+    "response.completed"
+  ]
+}

--- a/tests/integration/test_mocked_coordinator.cpp
+++ b/tests/integration/test_mocked_coordinator.cpp
@@ -249,8 +249,8 @@ TEST_CASE("Mocked Tier B: predict routes to correct model and returns text", "[i
 
     InferenceRequest req;
     req.prompt = "What is 2+2?";
-    req.max_tokens = 16;
-    req.temperature = 0.0f;
+    req.max_output_tokens = 16;
+    req.sampling.temperature = 0.0f;
     auto r = c.predict("qwen3.6-27b", s.value(), req);
     REQUIRE(r.has_value());
     REQUIRE(r.value().text == "hello world");
@@ -308,9 +308,9 @@ TEST_CASE("Mocked Tier B: opencode coding fixture flows through coordinator", "[
 
     InferenceRequest req;
     req.prompt = j.value("model", std::string{"qwen3.6-27b"});
-    if (j.contains("max_tokens")) req.max_tokens = j["max_tokens"].get<int>();
-    if (j.contains("temperature")) req.temperature = j["temperature"].get<float>();
-    if (j.contains("top_p")) req.top_p = j["top_p"].get<float>();
+    if (j.contains("max_tokens")) req.max_output_tokens = j["max_tokens"].get<int>();
+    if (j.contains("temperature")) req.sampling.temperature = j["temperature"].get<float>();
+    if (j.contains("top_p")) req.sampling.top_p = j["top_p"].get<float>();
 
     auto r = c.predict("qwen3.6-27b", slot.value(), req);
     REQUIRE(r.has_value());


### PR DESCRIPTION
## Summary
- add protocol-neutral typed inference contracts and llama adapter
- remove protocol parsing from model/runtime layers
- share GenerationSession across Chat and Responses
- emit Responses output directly from canonical results and deltas
- add dependency-policy and fixture-backed adapter golden gates

## Verification
- Release gateway build passed
- ctest -C Release -L unit|integration: 127/127 passed
- canonical request and Responses SSE golden fixtures passed
- source policy found no HTTP or protocol dependency in model/runtime sources
- git diff --check passed

## Architecture
- remains one native in-process executable
- adds no subprocess or proxy runtime
- strict OpenAI core namespace remains unchanged

Refs #113