### PR TITLE
Phase 10: reproducible Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,10 @@ jobs:
 
           # Dashboard static assets (copied post-build by CMake)
           Copy-Item -Recurse build\bin\Release\static dist\
-          New-Item -ItemType Directory -Path dist\config\templates, dist\data, dist\ops -Force | Out-Null
+          New-Item -ItemType Directory -Path dist\config\templates, dist\data -Force | Out-Null
           Copy-Item config\gateway.yml dist\config\
           Copy-Item config\templates\* dist\config\templates\
           Copy-Item data\pricing.json dist\data\
-          Copy-Item ops\*.ps1 dist\ops\
 
           # llama.cpp + ggml DLLs built from source (live alongside the exe)
           Copy-Item build\bin\Release\*.dll dist\


### PR DESCRIPTION
## Outcome
- makes VERSION 0.8.0 authoritative across CMake, native binaries, dashboard, and package metadata
- pins the Windows runner, Vulkan SDK download/checksum, vcpkg baseline, Whisper model revision/checksum, submodules, and GitHub Actions
- emits dependency provenance, SPDX SBOM, per-file manifest, archive checksum, and conditional verified signatures
- removes developer-machine Vulkan fallback and documents the reproducibility/update policy

## Verification
- fresh short-path manifest configure and full Release build
- clean CTest unit/integration: 131/131
- dashboard: 41/41 plus production build
- official OpenAI JS SDK contract: 2/2
- official OpenAI Python SDK contract: 1/1
- pinned Whisper runtime provisioning passed
- clean binaries report 0.8.0
- release archive/manifest/SHA256 validation passed (26 files, 25,135,622 bytes)
- workflow YAML and all PowerShell scripts parse cleanly
- git diff --check

Refs #120