### PR TITLE
Phase 11: required architecture CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: Required CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'codex/**'
+
+permissions:
+  contents: read
+
+jobs:
+  architecture-policy:
+    name: Architecture policy
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          submodules: recursive
+      - shell: pwsh
+        run: .\scripts\Test-ArchitecturePolicy.ps1 -SelfTest
+      - shell: pwsh
+        run: .\scripts\Test-StaticPolicy.ps1
+
+  dashboard-contracts:
+    name: Dashboard and SDK contracts
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.13'
+      - shell: pwsh
+        run: pnpm install --frozen-lockfile
+      - shell: pwsh
+        run: pnpm --filter dashboard typecheck
+      - shell: pwsh
+        run: pnpm --filter dashboard test
+      - shell: pwsh
+        run: pnpm --filter dashboard build
+      - shell: pwsh
+        run: pnpm test:openai-contract
+      - shell: pwsh
+        run: python -m pip install --disable-pip-version-check -r Testing/requirements-openai-contract.txt
+      - shell: pwsh
+        run: python -m unittest -v Testing.openai_sdk_contract_test
+
+  native-contracts:
+    name: Native architecture and security
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          submodules: recursive
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: build/vcpkg_installed
+          key: ci-vcpkg-x64-windows-${{ hashFiles('vcpkg.json') }}
+      - shell: pwsh
+        run: |
+          $version = '1.4.309.0'
+          $expected = '48b132169b64fe65cdb0f20970195335a65354e73f1ea5373032c2a8bbad4297'
+          $root = "C:\VulkanSDK\$version"
+          if (!(Test-Path "$root\Bin\glslc.exe")) {
+            $installer = "$env:RUNNER_TEMP\VulkanSDK-$version-Installer.exe"
+            Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$version/windows/vulkan_sdk.exe" -OutFile $installer
+            if ((Get-FileHash $installer -Algorithm SHA256).Hash.ToLowerInvariant() -ne $expected) { throw 'Vulkan SDK checksum mismatch' }
+            $process = Start-Process $installer -ArgumentList '--accept-licenses --default-answer --confirm-command install' -Wait -PassThru -WindowStyle Hidden
+            if ($process.ExitCode -ne 0) { throw "Vulkan SDK installer failed: $($process.ExitCode)" }
+          }
+          if (!(Test-Path "$root\Include\vulkan\vulkan.h") -or !(Test-Path "$root\Lib\vulkan-1.lib") -or !(Test-Path "$root\Bin\glslc.exe")) { throw 'Pinned Vulkan SDK is incomplete' }
+          "VULKAN_SDK=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - shell: pwsh
+        run: .\scripts\setup-whisper-runtime.ps1 -RuntimeRoot runtime -SkipModel
+      - shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $version = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
+          if (!$version) { throw 'Visual Studio with MSBuild is unavailable' }
+          $generator = if ($version.StartsWith('18.')) { 'Visual Studio 18 2026' } else { 'Visual Studio 17 2022' }
+          cmake -S . -B build -G $generator -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DINFERDECK_BUILD_TESTS=ON -DINFERDECK_REQUIRE_WHISPER_CPP=ON
+      - shell: pwsh
+        run: cmake --build build --config Release --parallel
+      - shell: pwsh
+        run: ctest --test-dir build -C Release --output-on-failure -L 'unit|integration'

--- a/Testing/Test-ControlPlaneSecurity.ps1
+++ b/Testing/Test-ControlPlaneSecurity.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$Gateway = 'build\bin\Release\inferdeck-gateway.exe',
     [string]$Config = 'config\gateway.test-security.yml',
-    [string]$LanAddress = '192.168.0.168',
+    [string]$LanAddress = '',
     [int]$Port = 11439,
     [int]$StartupTimeoutSeconds = 55,
     [switch]$RemoteControl,
@@ -19,6 +19,17 @@ if ($RemoteControl) {
 }
 $gatewayPath = (Resolve-Path -LiteralPath $Gateway).Path
 $configPath = (Resolve-Path -LiteralPath $Config).Path
+if (-not $LanAddress) {
+    $LanAddress = [Net.Dns]::GetHostAddresses([Net.Dns]::GetHostName()) |
+        Where-Object {
+            $_.AddressFamily -eq [Net.Sockets.AddressFamily]::InterNetwork -and
+            -not [Net.IPAddress]::IsLoopback($_)
+        } |
+        Select-Object -First 1 -ExpandProperty IPAddressToString
+    if (-not $LanAddress) {
+        throw 'No non-loopback IPv4 address is available for the remote-control security probe'
+    }
+}
 $logSuffix = [DateTime]::UtcNow.ToString('yyyyMMddHHmmssfff')
 $logDirectory = Split-Path $gatewayPath -Parent
 $stdoutPath = Join-Path $logDirectory "security-fixture-$Port-$logSuffix.stdout.log"

--- a/scripts/Test-ArchitecturePolicy.ps1
+++ b/scripts/Test-ArchitecturePolicy.ps1
@@ -1,0 +1,125 @@
+param(
+    [string]$Root = (Split-Path -Parent $PSScriptRoot),
+    [switch]$SelfTest
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path -LiteralPath $Root).Path
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Add-Failure([string]$Message) {
+    $failures.Add($Message)
+}
+
+function Test-CoreText([string]$RelativePath, [string]$Text) {
+    $normalized = $RelativePath.Replace('\', '/')
+    if ($Text -match '(?i)\b(system|popen|_popen|CreateProcess[AW]?|ShellExecute[AW]?|WinExec)\s*\(' -or
+        $Text -match '(?i)llama-server\.exe|subprocess\.') {
+        Add-Failure "${normalized}: forbidden process or proxy launch"
+    }
+    if ($normalized -match '^libs/(model|llama_cpp_wrapper|native_runtimes)/' -and
+        $Text -match '(?i)httplib|openai_body_json|chat\.completion|stream_options') {
+        Add-Failure "${normalized}: protocol leaked below the gateway adapter"
+    }
+    if ($normalized -match '^libs/(model|native_runtimes)/' -and
+        $Text -match 'nlohmann::json::parse\s*\(') {
+        Add-Failure "${normalized}: backend parses wire JSON"
+    }
+    if ($normalized -match '^libs/foundation/' -and
+        $Text -match '#include\s*[<\"](?:inference|model|llama_cpp_wrapper|native_runtimes|observability|gateway)/') {
+        Add-Failure "${normalized}: foundation dependency points upward"
+    }
+    if ($normalized -match '^libs/inference/' -and
+        $Text -match '#include\s*[<\"](?:model|llama_cpp_wrapper|native_runtimes|observability|gateway)/') {
+        Add-Failure "${normalized}: inference dependency points upward"
+    }
+    if ($normalized -match '^libs/model/' -and
+        $Text -match '#include\s*[<\"](?:llama_cpp_wrapper|native_runtimes|observability|gateway)/') {
+        Add-Failure "${normalized}: model dependency points upward"
+    }
+}
+
+function Test-StrictPath([string]$Path) {
+    $allowed = @(
+        '/v1/models',
+        '/v1/chat/completions',
+        '/v1/responses',
+        '/v1/embeddings',
+        '/v1/images/generations',
+        '/v1/audio/speech',
+        '/v1/audio/transcriptions'
+    )
+    if ($Path.StartsWith('/v1/') -and $Path -notin $allowed) {
+        Add-Failure "${Path}: non-OpenAI route in strict Core"
+    }
+}
+
+function Test-ControlClassification([string]$Path, [string]$Principal) {
+    if ($Path.StartsWith('/api/') -and $Principal -eq 'PublicStatus') {
+        Add-Failure "${Path}: control route is unauthenticated"
+    }
+}
+
+function Test-SseTerminator([string]$Chunk) {
+    if ($Chunk -notmatch 'data: \[DONE\](?:\r?\n){2}$') {
+        Add-Failure 'strict SSE stream has no valid terminal chunk'
+    }
+}
+
+$scanRoots = @(
+    'apps/inferdeck-gateway/src',
+    'libs/foundation/include', 'libs/foundation/src',
+    'libs/inference/include', 'libs/inference/src',
+    'libs/model/include', 'libs/model/src',
+    'libs/llama_cpp_wrapper/include', 'libs/llama_cpp_wrapper/src',
+    'libs/native_runtimes/include', 'libs/native_runtimes/src',
+    'libs/observability/include', 'libs/observability/src',
+    'libs/gateway/include', 'libs/gateway/src'
+)
+foreach ($relativeRoot in $scanRoots) {
+    $path = Join-Path $repoRoot $relativeRoot
+    if (!(Test-Path -LiteralPath $path)) { continue }
+    Get-ChildItem -LiteralPath $path -Recurse -File | Where-Object Extension -in '.cpp', '.hpp' | ForEach-Object {
+        $relative = $_.FullName.Substring($repoRoot.Length).TrimStart('\', '/')
+        Test-CoreText $relative (Get-Content -LiteralPath $_.FullName -Raw)
+    }
+}
+
+$manifest = Get-Content -LiteralPath (Join-Path $repoRoot 'tests/fixtures/openai_route_manifest.json') -Raw | ConvertFrom-Json
+foreach ($route in $manifest.routes) { Test-StrictPath $route.path }
+if ($manifest.profile -ne 'strict_openai' -or $manifest.routes.Count -ne 7) {
+    Add-Failure 'strict route manifest identity or count changed'
+}
+
+$authText = Get-Content -LiteralPath (Join-Path $repoRoot 'libs/gateway/include/gateway/auth.hpp') -Raw
+if ($authText -notmatch 'path\.starts_with\("/api/"\)' -or
+    $authText -notmatch 'RoutePrincipal::ControlRead' -or
+    $authText -notmatch 'RoutePrincipal::ControlWrite') {
+    Add-Failure 'control route classification is incomplete'
+}
+Test-ControlClassification '/api/inferdeck/v1/status' 'DashboardSession'
+
+$routeTests = Get-Content -LiteralPath (Join-Path $repoRoot 'libs/gateway/tests/test_routes.cpp') -Raw
+if ($routeTests -notmatch 'Chat stream serializers preserve exact OpenAI event ordering') {
+    Add-Failure 'strict SSE golden test is missing'
+}
+Test-SseTerminator "data: [DONE]`n`n"
+
+if ($SelfTest) {
+    $before = $failures.Count
+    Test-CoreText 'libs/model/src/broken.cpp' 'CreateProcessW(nullptr, command, nullptr, nullptr, false, 0, nullptr, nullptr, nullptr, nullptr);'
+    Test-CoreText 'libs/model/src/broken.cpp' 'auto body = nlohmann::json::parse(request.body);'
+    Test-StrictPath '/v1/vendor/messages'
+    Test-ControlClassification '/api/inferdeck/v1/unprotected' 'PublicStatus'
+    Test-SseTerminator "data: {}`n"
+    if ($failures.Count -ne $before + 5) {
+        throw "Architecture policy self-test expected five violations; observed $($failures.Count - $before)"
+    }
+    $failures.RemoveRange($before, 5)
+}
+
+if ($failures.Count -gt 0) {
+    $failures | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+Write-Output 'ARCHITECTURE_POLICY_OK'

--- a/scripts/Test-StaticPolicy.ps1
+++ b/scripts/Test-StaticPolicy.ps1
@@ -1,0 +1,25 @@
+param([string]$Root = (Split-Path -Parent $PSScriptRoot))
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path -LiteralPath $Root).Path
+& git -C $repoRoot diff --check
+if ($LASTEXITCODE -ne 0) { throw 'git whitespace validation failed' }
+
+Get-ChildItem -LiteralPath (Join-Path $repoRoot 'scripts') -Filter *.ps1 -File -Recurse |
+    ForEach-Object {
+        $tokens = $null
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+        if ($errors.Count -gt 0) { throw "PowerShell parse failed: $($_.FullName): $($errors[0].Message)" }
+    }
+
+& git -C $repoRoot ls-files '*.json' | ForEach-Object {
+        $jsonPath = Join-Path $repoRoot $_
+        try {
+            Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json | Out-Null
+        } catch {
+            throw "JSON parse failed: ${jsonPath}: $($_.Exception.Message)"
+        }
+    }
+
+Write-Output 'STATIC_POLICY_OK'


### PR DESCRIPTION
## Outcome
- adds separate pull-request and normal-push CI with immutable Actions and the pinned Windows toolchain
- makes dashboard tests/build, Python and JavaScript OpenAI SDK contracts, full labeled native tests, and both control-security matrices first-class gates
- adds non-rewriting type/static/format checks
- adds architecture lint for subprocess/proxy launches, dependency direction, protocol leaks, backend wire-JSON parsing, strict route inventory, control-route classification, and SSE termination
- self-tests five deliberately broken cases: SSE chunk, process launch, vendor /v1 route, backend JSON parse, and unauthenticated control route

## Local verification
- architecture policy and five mutation checks passed
- static/format policy passed
- workflow YAML parsed successfully
- inherited clean build gates: 131/131 native, dashboard 41/41, OpenAI JS 2/2, OpenAI Python 1/1

Refs #120