### PR TITLE
Fix missing OpenSSL release runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,15 @@ jobs:
           SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
         run: .\scripts\Sign-ReleaseArtifacts.ps1 -Executable dist\inferdeck-gateway.exe -CertificateBase64 $env:SIGNING_CERTIFICATE_BASE64 -CertificatePassword $env:SIGNING_CERTIFICATE_PASSWORD
 
+      - name: Verify packaged executable loads
+        shell: pwsh
+        run: |
+          $output = & .\dist\inferdeck-gateway.exe --version
+          if ($LASTEXITCODE -ne 0) { throw "Packaged executable failed to load: exit $LASTEXITCODE" }
+          if ($output -ne "inferdeck-gateway $env:INFERDECK_VERSION") {
+            throw "Unexpected packaged executable version output: $output"
+          }
+
       - name: Generate package metadata
         shell: pwsh
         run: .\scripts\New-ReleaseMetadata.ps1 -DistDir dist -OutputDir dist -VcpkgInstalledDir build\vcpkg_installed

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "spdlog",
     "catch2",
     "nlohmann-json",
+    "openssl",
     "fmt",
     "yaml-cpp",
     "sqlite3",


### PR DESCRIPTION
Fixes the v0.8.0 release-package loader failure found during live deployment.\n\n- pins OpenSSL in the vcpkg manifest so libssl/libcrypto runtime DLLs are collected\n- executes the packaged gateway with --version before metadata/package upload, making missing transitive DLLs a release-blocking failure\n- preserves the live StatsDb; rollback was completed with exact token totals\n\nThis is required before v0.8.0 can be redeployed or published.