### PR TITLE
fix(release): package sherpa runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,15 @@ jobs:
         run: .\scripts\setup-whisper-runtime.ps1 -RuntimeRoot runtime -SkipModel
       - shell: pwsh
         run: |
+          $root = .\scripts\setup-sherpa-runtime.ps1 -RuntimeRoot runtime
+          "INFERDECK_SHERPA_ONNX_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - shell: pwsh
+        run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $version = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
           if (!$version) { throw 'Visual Studio with MSBuild is unavailable' }
           $generator = if ($version.StartsWith('18.')) { 'Visual Studio 18 2026' } else { 'Visual Studio 17 2022' }
-          cmake -S . -B build -G $generator -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DINFERDECK_BUILD_TESTS=ON -DINFERDECK_REQUIRE_WHISPER_CPP=ON
+          cmake -S . -B build -G $generator -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DINFERDECK_BUILD_TESTS=ON -DINFERDECK_REQUIRE_WHISPER_CPP=ON -DINFERDECK_SHERPA_ONNX_ROOT="$env:INFERDECK_SHERPA_ONNX_ROOT" -DINFERDECK_REQUIRE_SHERPA_ONNX=ON
       - shell: pwsh
         run: cmake --build build --config Release --parallel
       - shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,12 @@ jobs:
         shell: pwsh
         run: .\scripts\setup-whisper-runtime.ps1 -RuntimeRoot runtime -SkipModel
 
+      - name: Provision sherpa-onnx runtime
+        shell: pwsh
+        run: |
+          $root = .\scripts\setup-sherpa-runtime.ps1 -RuntimeRoot runtime
+          "INFERDECK_SHERPA_ONNX_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Select Visual Studio generator
         shell: pwsh
         run: |
@@ -108,7 +114,9 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DINFERDECK_BUILD_TESTS=ON `
-            -DINFERDECK_REQUIRE_WHISPER_CPP=ON
+            -DINFERDECK_REQUIRE_WHISPER_CPP=ON `
+            -DINFERDECK_SHERPA_ONNX_ROOT="$env:INFERDECK_SHERPA_ONNX_ROOT" `
+            -DINFERDECK_REQUIRE_SHERPA_ONNX=ON
 
       - name: Build
         run: cmake --build build --config Release --parallel
@@ -142,6 +150,12 @@ jobs:
           $vcpkgBin = "build\vcpkg_installed\x64-windows\bin"
           if (Test-Path $vcpkgBin) {
             Copy-Item "$vcpkgBin\*.dll" dist\ -ErrorAction SilentlyContinue
+          }
+
+          foreach ($runtimeDll in @('sherpa-onnx-c-api.dll', 'onnxruntime.dll', 'onnxruntime_providers_shared.dll')) {
+            if (!(Test-Path "dist\$runtimeDll" -PathType Leaf)) {
+              throw "Required native speech runtime is missing from the package: $runtimeDll"
+            }
           }
 
           Write-Host "=== dist contents ==="

--- a/docs/release-reproducibility.md
+++ b/docs/release-reproducibility.md
@@ -14,6 +14,10 @@ The Windows release environment is pinned to:
 - vcpkg baseline `77df67cfff9c12ccfdb52284e07c87c75092f723`;
 - llama.cpp submodule `adb55e5148dc93bcdca7212a2d1df3ccc422959a`;
 - Vulkan-Headers submodule `015e25c3c91b70eb1a754d36fb14c4ba6ad9b0b9`;
+- sherpa-onnx `v1.13.2` Windows shared runtime archive, SHA-256
+  `e1f9b7e6b17aec5a56ea1180ffd915a42eef86c7abf7a0749ddc530e0e0831e4`,
+  plus its pinned C API header, SHA-256
+  `437b1279047877167d8fadc74a60d47f3df514d703fdac1c1b6851da9bc2fdb4`;
 - immutable commit SHAs for every GitHub Action.
 
 `VULKAN_SDK` or `INFERDECK_VULKAN_SDK_ROOT` must identify the exact pinned SDK

--- a/libs/native_runtimes/CMakeLists.txt
+++ b/libs/native_runtimes/CMakeLists.txt
@@ -17,6 +17,7 @@ set(INFERDECK_STABLE_DIFFUSION_ROOT "" CACHE PATH "stable-diffusion.cpp source t
 set(INFERDECK_WHISPER_ROOT "${CMAKE_SOURCE_DIR}/runtime/whisper.cpp-src" CACHE PATH "whisper.cpp source tree")
 option(INFERDECK_REQUIRE_WHISPER_CPP "Fail configuration when whisper.cpp is unavailable" OFF)
 set(INFERDECK_SHERPA_ONNX_ROOT "" CACHE PATH "sherpa-onnx install prefix")
+option(INFERDECK_REQUIRE_SHERPA_ONNX "Fail configuration when sherpa-onnx is unavailable" OFF)
 set(INFERDECK_SHERPA_ONNX_RUNTIME_DIR "${INFERDECK_SHERPA_ONNX_ROOT}/lib" CACHE PATH "sherpa-onnx runtime library directory")
 
 if(EXISTS "${INFERDECK_STABLE_DIFFUSION_ROOT}/CMakeLists.txt")
@@ -54,6 +55,8 @@ if(INFERDECK_SHERPA_ONNX_INCLUDE AND INFERDECK_SHERPA_ONNX_LIBRARY)
     target_include_directories(native_runtimes PRIVATE ${INFERDECK_SHERPA_ONNX_INCLUDE})
     target_link_libraries(native_runtimes PRIVATE ${INFERDECK_SHERPA_ONNX_LIBRARY})
     target_compile_definitions(native_runtimes PUBLIC INFERDECK_HAS_SHERPA_ONNX=1)
+elseif(INFERDECK_REQUIRE_SHERPA_ONNX)
+    message(FATAL_ERROR "sherpa-onnx is required but headers or libraries are unavailable under: ${INFERDECK_SHERPA_ONNX_ROOT}")
 endif()
 
 if(MSVC)

--- a/scripts/setup-sherpa-runtime.ps1
+++ b/scripts/setup-sherpa-runtime.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]$RuntimeRoot = "runtime",
+    [string]$Version = "1.13.2",
+    [string]$Sha256 = "e1f9b7e6b17aec5a56ea1180ffd915a42eef86c7abf7a0749ddc530e0e0831e4",
+    [string]$HeaderSha256 = "437b1279047877167d8fadc74a60d47f3df514d703fdac1c1b6851da9bc2fdb4"
+)
+
+$ErrorActionPreference = "Stop"
+
+$archiveName = "sherpa-onnx-v$Version-win-x64-shared-MD-Release-lib.tar.bz2"
+$installName = "sherpa-onnx-v$Version-win-x64-shared-MD-Release-lib"
+$installRoot = Join-Path $RuntimeRoot $installName
+$required = @(
+    (Join-Path $installRoot "include\sherpa-onnx\c-api\c-api.h"),
+    (Join-Path $installRoot "lib\sherpa-onnx-c-api.lib"),
+    (Join-Path $installRoot "lib\sherpa-onnx-c-api.dll"),
+    (Join-Path $installRoot "lib\onnxruntime.dll"),
+    (Join-Path $installRoot "lib\onnxruntime_providers_shared.dll")
+)
+
+if ($required | Where-Object { !(Test-Path -LiteralPath $_ -PathType Leaf) }) {
+    New-Item -ItemType Directory -Path $RuntimeRoot -Force | Out-Null
+    $archive = Join-Path ([System.IO.Path]::GetTempPath()) $archiveName
+    $url = "https://github.com/k2-fsa/sherpa-onnx/releases/download/v$Version/$archiveName"
+    Invoke-WebRequest -Uri $url -OutFile $archive
+    $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $Sha256) { throw "sherpa-onnx checksum mismatch: $actual" }
+    tar -xf $archive -C $RuntimeRoot
+    if ($LASTEXITCODE -ne 0) { throw "Unable to extract $archiveName" }
+}
+
+$header = Join-Path $installRoot "include\sherpa-onnx\c-api\c-api.h"
+if (!(Test-Path -LiteralPath $header -PathType Leaf)) {
+    $headerDownload = Join-Path ([System.IO.Path]::GetTempPath()) "sherpa-onnx-v$Version-c-api.h"
+    $headerUrl = "https://raw.githubusercontent.com/k2-fsa/sherpa-onnx/v$Version/sherpa-onnx/c-api/c-api.h"
+    Invoke-WebRequest -Uri $headerUrl -OutFile $headerDownload
+    $actualHeader = (Get-FileHash -LiteralPath $headerDownload -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHeader -ne $HeaderSha256) { throw "sherpa-onnx header checksum mismatch: $actualHeader" }
+    New-Item -ItemType Directory -Path (Split-Path -Parent $header) -Force | Out-Null
+    Copy-Item -LiteralPath $headerDownload -Destination $header
+}
+
+$missing = @($required | Where-Object { !(Test-Path -LiteralPath $_ -PathType Leaf) })
+if ($missing.Count -ne 0) { throw "sherpa-onnx runtime is incomplete: $($missing -join ', ')" }
+
+(Resolve-Path -LiteralPath $installRoot).Path


### PR DESCRIPTION
## Summary

- provision and checksum sherpa-onnx v1.13.2 plus its pinned C API header
- require sherpa in protected CI and release configuration
- fail packaging unless sherpa and ONNX Runtime DLLs are present

## Evidence

- live v0.8.0 candidate returned 503 speech_validation_failed: runtime not registered: sherpa_onnx
- clean pinned setup produced all required headers, import libraries, and runtime DLLs
- required-sherpa Release gateway and native_runtime_tests build passed
- architecture policy passed
- 130/130 unit and integration tests passed

The uncommitted Ornith configuration change is excluded.