### PR TITLE
Export live models and aliases to OpenCode

### DIFF
--- a/Testing/export-opencode-config.test.mjs
+++ b/Testing/export-opencode-config.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildOpenCodeModels, mergeOpenCodeConfig, parseArguments } from '../scripts/export-opencode-config.mjs';
+
+const advertised = [
+  { id: 'ornith-1.5-35b-a3b', context_size: 100000, has_vision: true, reasoning: { supported: true, efforts: ['low', 'medium', 'high'], none_disables: false } },
+  { id: 'qwen3.8-27b', context_size: 100000, has_vision: true, reasoning: { supported: true, efforts: ['low', 'medium', 'xhigh'], none_disables: true } },
+  { id: 'n8n-model', alias: true, required_context_size: 100000, has_vision: true },
+  { id: 'Normal', alias: true, required_context_size: 100000, has_vision: true },
+  { id: 'Pro', alias: true, required_context_size: 100000, has_vision: true },
+];
+
+test('parses explicit exporter selections', () => {
+  assert.deepEqual(parseArguments(['--base-url', 'http://host:11434/', '--model', 'Pro']), {
+    baseUrl: 'http://host:11434', sourceUrl: 'http://host:11434', output: 'opencode.json', provider: 'inferdeck', model: 'Pro', smallModel: undefined,
+  });
+});
+
+test('exports aliases and reasoning capabilities', () => {
+  const models = buildOpenCodeModels(advertised);
+  assert.deepEqual(models.Normal.modalities.input, ['text', 'image']);
+  assert.equal(models.Normal.limit.context, 100000);
+  assert.equal(models['qwen3.8-27b'].variants.off.reasoningEffort, 'none');
+});
+
+test('preserves unrelated settings and selects stable aliases', () => {
+  const output = mergeOpenCodeConfig({ plugin: ['keep-me'], mcp: { keep: true } }, advertised, {
+    baseUrl: 'http://192.168.0.168:11434', provider: 'inferdeck', model: 'Normal', smallModel: 'n8n-model',
+  });
+  assert.deepEqual(output.plugin, ['keep-me']);
+  assert.deepEqual(output.mcp, { keep: true });
+  assert.equal(output.model, 'inferdeck/Normal');
+  assert.equal(output.small_model, 'inferdeck/n8n-model');
+  assert.ok(output.provider.inferdeck.models.Pro);
+});
+
+test('rejects aliases not advertised by InferDeck', () => {
+  assert.throws(() => mergeOpenCodeConfig({}, advertised, {
+    baseUrl: 'http://127.0.0.1:11434', provider: 'inferdeck', model: 'missing', smallModel: undefined,
+  }), /not advertised/);
+});

--- a/docs/opencode-setup-guide.md
+++ b/docs/opencode-setup-guide.md
@@ -22,11 +22,33 @@ cd C:\Users\david\Documents\GitHub\InferDeck
 opencode
 ```
 
+Before starting OpenCode, export the live model catalog. The exporter reads
+concrete models and stable aliases from InferDeck, replaces only the InferDeck
+provider catalog, and preserves unrelated OpenCode plugins, MCP servers, and
+settings:
+
+```powershell
+pnpm export:opencode -- --source-url http://127.0.0.1:11434 `
+  --base-url http://192.168.0.168:11434 `
+  --model Normal --small-model n8n-model --output opencode.json
+```
+
+The resulting OpenAI-compatible model names include `Normal`, `Pro`, and
+`n8n-model` whenever the gateway advertises those aliases. Re-export after any
+model or alias change. When remote control authentication is enabled, set
+`INFERDECK_CONTROL_TOKEN`; the exporter sends it as a bearer header and never
+writes it into `opencode.json`.
+
 ## Provider
+
+The exported provider uses the requested gateway address and `/v1` data-plane
+base.
 
 | Provider | Endpoint | Use Case |
 |---|---|---|
-| `inferdeck/qwen36` | `http://127.0.0.1:11434/v1` | Primary — in-process gateway |
+| `inferdeck/Normal` | configured by `--base-url` | Stable normal-work alias |
+| `inferdeck/Pro` | configured by `--base-url` | Stable demanding-work alias |
+| `inferdeck/n8n-model` | configured by `--base-url` | Stable automation alias |
 
 ## Context Limits
 

--- a/libs/gateway/src/dashboard_routes.cpp
+++ b/libs/gateway/src/dashboard_routes.cpp
@@ -375,6 +375,13 @@ nlohmann::json build_dashboard_models(model::BackendCoordinator& coordinator) {
             {"active_requests", resident == residency.end() ? 0 : resident->second.active_requests},
             {"resizing", resident != residency.end() && resident->second.resizing},
             {"has_vision", info.has_vision},
+            {"reasoning", {
+                {"supported", info.reasoning.supported},
+                {"efforts", info.reasoning.efforts},
+                {"default", info.reasoning.default_effort},
+                {"none_disables", info.reasoning.none_disables},
+                {"aliases", info.reasoning.aliases},
+            }},
             {"optimization", {
                 {"status", info.optimization.status},
                 {"measured_at", info.optimization.measured_at},
@@ -412,6 +419,13 @@ nlohmann::json build_dashboard_models(model::BackendCoordinator& coordinator) {
             {"free_slots", resident == residency.end() ? 0 : resident->second.free_slots},
             {"active_requests", resident == residency.end() ? 0 : resident->second.active_requests},
             {"has_vision", info->has_vision},
+            {"reasoning", {
+                {"supported", info->reasoning.supported},
+                {"efforts", info->reasoning.efforts},
+                {"default", info->reasoning.default_effort},
+                {"none_disables", info->reasoning.none_disables},
+                {"aliases", info->reasoning.aliases},
+            }},
             {"alias", true},
             {"alias_target", alias.target},
             {"required_context_size", alias.required_context_size},

--- a/libs/gateway/tests/test_dashboard_config_routes.cpp
+++ b/libs/gateway/tests/test_dashboard_config_routes.cpp
@@ -569,6 +569,10 @@ TEST_CASE("Control model inventory retains InferDeck runtime fields",
     info.context_size = 65536;
     info.vram_required_mb = 8192;
     info.n_slots = 2;
+    info.reasoning.supported = true;
+    info.reasoning.efforts = {"low", "high"};
+    info.reasoning.default_effort = "high";
+    info.reasoning.none_disables = true;
     routes.registry.register_model(info);
 
     auto client = routes.client();
@@ -581,6 +585,11 @@ TEST_CASE("Control model inventory retains InferDeck runtime fields",
     CHECK(body["models"][0]["runtime"] == "llama_cpp");
     CHECK(body["models"][0]["context_size"] == 65536);
     CHECK(body["models"][0]["vram_required_mb"] == 8192);
+    CHECK(body["models"][0]["reasoning"]["supported"] == true);
+    CHECK(body["models"][0]["reasoning"]["efforts"] ==
+          nlohmann::json::array({"low", "high"}));
+    CHECK(body["models"][0]["reasoning"]["default"] == "high");
+    CHECK(body["models"][0]["reasoning"]["none_disables"] == true);
     CHECK(body["models"][0]["loaded"] == false);
 }
 

--- a/opencode.json
+++ b/opencode.json
@@ -13,75 +13,260 @@
         "baseURL": "http://192.168.0.168:11434/v1"
       },
       "models": {
-        "qwen3.6-35b-a3b": {
-          "name": "qwen3.6-35b-a3b",
-          "limit": { "context": 100096, "output": 8192 },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "qwen3-coder-30b-a3b": {
-          "name": "qwen3-coder-30b-a3b",
-          "limit": { "context": 262144, "output": 16384 },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "qwen3-coder-next": {
-          "name": "qwen3-coder-next",
-          "limit": { "context": 262144, "output": 16384 },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
         "gemma-4-26b-a4b": {
           "name": "gemma-4-26b-a4b",
-          "limit": { "context": 100000, "output": 16384 },
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemma-4-31b": {
           "name": "gemma-4-31b",
-          "limit": { "context": 65536, "output": 16384 },
+          "limit": {
+            "context": 262144,
+            "output": 16384
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss-20b": {
           "name": "gpt-oss-20b",
-          "limit": { "context": 32768, "output": 8192 },
+          "limit": {
+            "context": 32768,
+            "output": 16384
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "n8n-model": {
+          "name": "n8n-model",
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "Normal": {
+          "name": "Normal",
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "ornith-1.5-35b-a3b": {
+          "name": "ornith-1.5-35b-a3b",
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "parakeet-tdt-0.6b-v3": {
+          "name": "parakeet-tdt-0.6b-v3",
+          "limit": {
+            "context": 65536,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "Pro": {
+          "name": "Pro",
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2.5-coder-3b": {
           "name": "qwen2.5-coder-3b",
-          "limit": { "context": 32768, "output": 16384 },
+          "limit": {
+            "context": 32768,
+            "output": 16384
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3-coder-30b-a3b": {
+          "name": "qwen3-coder-30b-a3b",
+          "limit": {
+            "context": 262144,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3-coder-next": {
+          "name": "qwen3-coder-next",
+          "limit": {
+            "context": 262144,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-27b": {
           "name": "qwen3.6-27b",
-          "limit": { "context": 100000, "output": 8192 },
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.6-35b-a3b": {
+          "name": "qwen3.6-35b-a3b",
+          "limit": {
+            "context": 100096,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen3.8-27b": {
+          "name": "qwen3.8-27b",
+          "limit": {
+            "context": 100000,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "supertonic-3": {
+          "name": "supertonic-3",
+          "limit": {
+            "context": 65536,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "whisper-base-en": {
+          "name": "whisper-base-en",
+          "limit": {
+            "context": 65536,
+            "output": 16384
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       }
     }
   },
-  "model": "inferdeck/qwen3-coder-30b-a3b",
-  "small_model": "inferdeck/qwen2.5-coder-3b",
+  "model": "inferdeck/Normal",
+  "small_model": "inferdeck/n8n-model",
   "plugin": [
     "@tarquinen/opencode-dcp",
     "@mohak34/opencode-notifier@latest",
@@ -92,7 +277,11 @@
   "mcp": {
     "puppeteer-screenshot-mcp": {
       "type": "local",
-      "command": ["npx", "-y", "puppeteer-screenshot-mcp"],
+      "command": [
+        "npx",
+        "-y",
+        "puppeteer-screenshot-mcp"
+      ],
       "enabled": true
     }
   }

--- a/overhall_plan.md
+++ b/overhall_plan.md
@@ -659,6 +659,8 @@ current implementation cannot satisfy the native single-process rule.
 - [x] Identify every local consumer: OpenCode, Open WebUI, dashboard, scripts,
       benchmarks, editor integrations and health monitors.
 - [x] Update consumers to strict OpenAI or the new control-plane endpoints.
+- [ ] Generate OpenCode provider configuration from the live model and stable
+      alias catalog; track implementation and deployment in #142.
 - [x] Back up configuration, StatsDb and managed-model manifests.
 - [x] Build matched gateway and dashboard artifacts from one revision.
 - [x] Run the complete clean verification matrix.
@@ -727,6 +729,23 @@ current implementation cannot satisfy the native single-process rule.
 - [x] Close linked issues only with source, test, artifact and live evidence.
 - [x] Close the overhaul epic after every child issue is resolved.
 - [x] Update this file so every completed checkbox reflects verified reality.
+
+### Post-release remediation (2026-08-23)
+
+- [x] Reopen the overhaul epic and Phase 14 after discovering that OpenCode had
+      only a stale hand-maintained consumer file and no exporter.
+- [x] Back up and repair the rejected live active profile by removing only its
+      obsolete top-level `anthropic` block.
+- [x] Verify the repaired profile is active and that lifetime token totals did
+      not decrease; StatsDb was not modified or migrated.
+- [x] Restore and persist `Normal`, `Pro`, and `n8n-model` after the active
+      profile reload exposed their absence from the persisted profile.
+- [x] Merge the already-deployed authenticated LAN dashboard change in #141.
+- [ ] Merge #142 implementation through protected CI.
+- [ ] Deploy its matched gateway artifact and re-export OpenCode from the live
+      post-deployment catalog.
+- [ ] Close #142, Phase 14, and the epic only after the new live evidence is
+      attached.
 
 ## Audit finding coverage matrix
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "dev:dashboard": "pnpm --filter dashboard dev",
     "build:dashboard": "pnpm --filter dashboard build",
-    "test:openai-contract": "node --test Testing/openai-sdk-stream-contract.test.mjs"
+    "test:openai-contract": "node --test Testing/openai-sdk-stream-contract.test.mjs",
+    "test:opencode-export": "node --test Testing/export-opencode-config.test.mjs",
+    "export:opencode": "node scripts/export-opencode-config.mjs"
   },
   "devDependencies": {
     "openai": "7.5.0"

--- a/scripts/export-opencode-config.mjs
+++ b/scripts/export-opencode-config.mjs
@@ -1,0 +1,107 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+export function parseArguments(argv) {
+  const options = { baseUrl: 'http://127.0.0.1:11434', sourceUrl: undefined, output: 'opencode.json', provider: 'inferdeck', model: undefined, smallModel: undefined };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === '--base-url' && value) options.baseUrl = value, index += 1;
+    else if (argument === '--source-url' && value) options.sourceUrl = value, index += 1;
+    else if (argument === '--output' && value) options.output = value, index += 1;
+    else if (argument === '--provider' && value) options.provider = value, index += 1;
+    else if (argument === '--model' && value) options.model = value, index += 1;
+    else if (argument === '--small-model' && value) options.smallModel = value, index += 1;
+    else if (argument === '--help') options.help = true;
+    else throw new Error(`unknown or incomplete argument: ${argument}`);
+  }
+  options.baseUrl = options.baseUrl.replace(/\/+$/, '');
+  options.sourceUrl = (options.sourceUrl ?? options.baseUrl).replace(/\/+$/, '');
+  return options;
+}
+
+function reasoningVariants(reasoning) {
+  if (!reasoning?.supported || !Array.isArray(reasoning.efforts)) return undefined;
+  const variants = Object.fromEntries(reasoning.efforts.map((effort) => [effort, { reasoningEffort: effort }]));
+  if (reasoning.none_disables) variants.off = { reasoningEffort: 'none' };
+  return variants;
+}
+
+export function buildOpenCodeModels(models) {
+  return Object.fromEntries(models
+    .filter((model) => typeof model.id === 'string' && model.id.length > 0)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((model) => {
+      const context = Number(model.required_context_size || model.context_size || 32768);
+      const entry = {
+        name: model.id,
+        limit: { context, output: Math.min(16384, context) },
+        modalities: { input: model.has_vision ? ['text', 'image'] : ['text'], output: ['text'] },
+      };
+      const variants = reasoningVariants(model.reasoning);
+      if (variants) entry.reasoning = true, entry.variants = variants;
+      return [model.id, entry];
+    }));
+}
+
+export function mergeOpenCodeConfig(existing, models, options) {
+  const ids = new Set(models.map((model) => model.id));
+  const aliases = models.filter((model) => model.alias).map((model) => model.id);
+  const concrete = models.filter((model) => !model.alias).map((model) => model.id);
+  const choose = (requested, current, preferred) => {
+    if (requested) {
+      if (!ids.has(requested)) throw new Error(`model is not advertised by InferDeck: ${requested}`);
+      return requested;
+    }
+    const currentId = typeof current === 'string' ? current.split('/').at(-1) : undefined;
+    return ids.has(currentId) ? currentId : preferred.find((id) => ids.has(id));
+  };
+  const defaultId = choose(options.model, existing.model, ['Normal', 'n8n-model', 'Pro', ...aliases, ...concrete]);
+  const smallId = choose(options.smallModel, existing.small_model, ['n8n-model', 'Fast', 'Normal', ...aliases, ...concrete]);
+  if (!defaultId || !smallId) throw new Error('InferDeck did not advertise any models');
+  const provider = existing.provider?.[options.provider] ?? {};
+  return {
+    ...existing,
+    $schema: existing.$schema ?? 'https://opencode.ai/config.json',
+    provider: {
+      ...(existing.provider ?? {}),
+      [options.provider]: {
+        ...provider,
+        npm: '@ai-sdk/openai-compatible',
+        name: provider.name ?? 'InferDeck',
+        options: { ...(provider.options ?? {}), baseURL: `${options.baseUrl}/v1` },
+        models: buildOpenCodeModels(models),
+      },
+    },
+    model: `${options.provider}/${defaultId}`,
+    small_model: `${options.provider}/${smallId}`,
+  };
+}
+
+async function readExisting(path) {
+  try { return JSON.parse(await readFile(path, 'utf8')); }
+  catch (error) { if (error.code === 'ENOENT') return {}; throw error; }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write('Usage: node scripts/export-opencode-config.mjs [--base-url URL] [--source-url URL] [--output FILE] [--provider NAME] [--model ID] [--small-model ID]\n');
+    return;
+  }
+  const headers = { Accept: 'application/json' };
+  if (process.env.INFERDECK_CONTROL_TOKEN) headers.Authorization = `Bearer ${process.env.INFERDECK_CONTROL_TOKEN}`;
+  const response = await fetch(`${options.sourceUrl}/api/inferdeck/v1/models`, { headers });
+  if (!response.ok) throw new Error(`InferDeck models request failed: HTTP ${response.status}`);
+  const document = await response.json();
+  if (!Array.isArray(document.models)) throw new Error('InferDeck models response has no models array');
+  const existing = await readExisting(options.output);
+  const output = mergeOpenCodeConfig(existing, document.models, options);
+  await writeFile(options.output, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+  process.stdout.write(`Exported ${document.models.length} InferDeck models to ${options.output}\n`);
+}
+
+const invokedPath = process.argv[1]?.replaceAll('\\', '/');
+if (invokedPath && (import.meta.url === `file:///${invokedPath}` || import.meta.url === `file://${invokedPath}`)) {
+  main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exitCode = 1; });
+}


### PR DESCRIPTION
## Summary

- export OpenCode models and stable aliases from the authenticated InferDeck catalog
- preserve plugins and MCP settings while separating local discovery from the LAN client URL
- expose reasoning metadata for accurate variants
- repair the overhaul ledger and document the generated workflow

## Verification

- Release build passed
- 130/130 native unit and integration tests passed
- 42/42 dashboard tests and production build passed
- architecture policy passed
- OpenAI JavaScript SDK contracts passed
- 4/4 exporter contracts passed
- live active profile repaired with unchanged token totals
- Normal, Pro, and n8n-model persisted and advertised

Refs #107
Refs #122
Closes #142